### PR TITLE
DocC and XCTUnimplemented cleanup

### DIFF
--- a/Sources/XCTestDynamicOverlay/Documentation.docc/GettingStarted.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/GettingStarted.md
@@ -1,0 +1,130 @@
+# Getting Started
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+A real world example of using this is in our library, the [Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture). That library vends a `TestStore` type whose purpose is to make it easy to write tests for your application's logic. The `TestStore` uses `XCTFail` internally, and so that forces us to move the code to a dedicated test support module. However, due to how SPM works you cannot currently have that module in the same package as the main module, and so we would be forced to extract it to a separate _repo_. By loading `XCTFail` dynamically we can keep the code where it belongs.
+
+As another example, let's say you have an analytics dependency that is used all over your application:
+
+```swift
+struct AnalyticsClient {
+  var track: (Event) -> Void
+
+  struct Event: Equatable {
+    var name: String
+    var properties: [String: String]
+  }
+}
+```
+
+If you are disciplined about injecting dependencies, you probably have a lot of objects that take an analytics client as an argument (or maybe some other fancy form of DI):
+
+```swift
+class LoginViewModel: ObservableObject {
+  ...
+
+  init(analytics: AnalyticsClient) {
+    ...
+  }
+
+  ...
+}
+```
+
+When testing this view model you will need to provide an analytics client. Typically this means you will construct some kind of "test" analytics client that buffers events into an array, rather than sending live events to a server, so that you can assert on what events were tracked during a test:
+
+```swift
+func testLogin() {
+  var events: [AnalyticsClient.Event] = []
+  let viewModel = LoginViewModel(
+    analytics: .test { events.append($0) }
+  )
+
+  ...
+
+  XCTAssertEqual(events, [.init(name: "Login Success")])
+}
+```
+
+This works really well, and it's a great way to get test coverage on something that is notoriously difficult to test.
+
+However, some tests may not use analytics at all. It would make the test suite stronger if the tests that don't use the client could prove that it's never used. This would mean when new events are tracked you could be instantly notified of which test cases need to be updated.
+
+One way to do this is to create an instance of the `AnalyticsClient` type that simply performs an `XCTFail` inside the `track` endpoint:
+
+```swift
+import XCTest
+
+extension AnalyticsClient {
+  static let unimplemented = Self(
+    track: { _ in XCTFail("\(Self.self).track is unimplemented.") }
+  )
+}
+```
+
+With this you can write a test that proves analytics are never tracked, and even better you don't have to worry about buffering events into an array anymore:
+
+```swift
+func testValidation() {
+  let viewModel = LoginViewModel(
+    analytics: .unimplemented
+  )
+
+  ...
+}
+```
+
+However, you cannot ship this code with the target that defines `AnalyticsClient`. You either need to extract it out to a test support module (which means `AnalyticsClient` must also be extracted), or the code must be confined to a test target and thus not shareable.
+
+However, with XCTest Dynamic Overlay we can have our cake and eat it too 😋. We can define both the client type and the unimplemented instance right next to each in application code without needing to extract out needless modules or targets:
+
+```swift
+struct AnalyticsClient {
+  var track: (Event) -> Void
+
+  struct Event: Equatable {
+    var name: String
+    var properties: [String: String]
+  }
+}
+
+import XCTestDynamicOverlay
+
+extension AnalyticsClient {
+  static let unimplemented = Self(
+    track: { _ in XCTFail("\(Self.self).track is unimplemented.") }
+  )
+}
+```
+
+XCTest Dynamic Overlay also comes with a helper that simplifies this exact pattern: `XCTUnimplemented`. It creates failing closures for you:
+
+```swift
+extension AnalyticsClient {
+  static let unimplemented = Self(
+    track: XCTUnimplemented("\(Self.self).track")
+  )
+}
+```
+
+And it can simplify the work of more complex dependency endpoints, which can throw or need to return a value:
+
+```swift
+struct AppDependencies {
+  var date: () -> Date = Date.init,
+  var fetchUser: (User.ID) async throws -> User,
+  var uuid: () -> UUID = UUID.init
+}
+
+extension AppDependencies {
+  static let unimplemented = Self(
+    date: XCTUnimplemented("\(Self.self).date", placeholder: Date()),
+    fetchUser: XCTUnimplemented("\(Self.self).fetchUser"),
+    date: XCTUnimplemented("\(Self.self).uuid", placeholder: UUID())
+  )
+}
+```
+
+The above `placeholder` parameters can be left off, but will fatal error when the endpoint is called.

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/UnimplementedOverloads.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/UnimplementedOverloads.md
@@ -14,7 +14,7 @@ Various overloads of `XCTUnimplemented` for a number of closure types.
 - ``XCTUnimplemented(_:)-1jjkb``
 - ``XCTUnimplemented(_:placeholder:file:line:)-50but``
 - ``XCTUnimplemented(_:)-1tmq0``
-- ``XCTUnimplemented(_:placeholder:file:line:)-l4v2``
+- ``XCTUnimplemented(_:placeholder:file:line:)-2jqzu``
 - ``XCTUnimplemented(_:)-4iv80``
 - ``XCTUnimplemented(_:placeholder:file:line:)-9mvva``
 - ``XCTUnimplemented(_:)-2hloh``

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/UnimplementedOverloads.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/UnimplementedOverloads.md
@@ -1,0 +1,34 @@
+# Overloads
+
+Various overloads of `XCTUnimplemented` for a number of closure types.
+
+## Overview
+
+`XCTUnimplemented` is a massively-overloaded function that can satisfy a number of different closure types (throwing, async, etc.) up to an arity of 5 arguments.
+
+## Topics
+
+### Functions
+
+- ``XCTUnimplemented(_:placeholder:file:line:)-4cefg``
+- ``XCTUnimplemented(_:)-1jjkb``
+- ``XCTUnimplemented(_:placeholder:file:line:)-50but``
+- ``XCTUnimplemented(_:)-1tmq0``
+- ``XCTUnimplemented(_:placeholder:file:line:)-l4v2``
+- ``XCTUnimplemented(_:)-4iv80``
+- ``XCTUnimplemented(_:placeholder:file:line:)-9mvva``
+- ``XCTUnimplemented(_:)-2hloh``
+- ``XCTUnimplemented(_:placeholder:file:line:)-92nev``
+- ``XCTUnimplemented(_:)-6skqm``
+- ``XCTUnimplemented(_:placeholder:file:line:)-6wlpq``
+- ``XCTUnimplemented(_:)-9llzg``
+- ``XCTUnimplemented(_:placeholder:file:line:)-97hr8``
+- ``XCTUnimplemented(_:)-1osc7``
+- ``XCTUnimplemented(_:placeholder:file:line:)-qhqq``
+- ``XCTUnimplemented(_:)-26rd5``
+- ``XCTUnimplemented(_:placeholder:file:line:)-4akkm``
+- ``XCTUnimplemented(_:)-7j8g3``
+- ``XCTUnimplemented(_:placeholder:file:line:)-5i77i``
+- ``XCTUnimplemented(_:)-1qks2``
+- ``XCTUnimplemented(_:placeholder:file:line:)-4xhs3``
+- ``XCTUnimplemented(_:)-6r8mf``

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/XCTestDynamicOverlay.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/XCTestDynamicOverlay.md
@@ -20,7 +20,7 @@ XCTest Dynamic Overlay provides APIs for invoking XCTest's `XCTFail` directly in
 
 ### Unimplemented Dependencies
 
-- ``XCTUnimplemented(_:placeholder:file:line:)-2jqzu``
+- ``XCTUnimplemented(_:placeholder:file:line:)-l4v2``
 - ``XCTUnimplemented(_:)-3obl5``
 - <doc:UnimplementedOverloads>
 - ``XCTUnimplementedFailure``

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/XCTestDynamicOverlay.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/XCTestDynamicOverlay.md
@@ -1,0 +1,26 @@
+# ``XCTestDynamicOverlay``
+
+Define XCTest assertion helpers directly in your application and library code.
+
+## Overview
+
+XCTest Dynamic Overlay provides APIs for invoking XCTest's `XCTFail` directly in your application and library code.
+
+## Topics
+
+### Essentials
+
+- <doc:GettingStarted>
+
+<!--NB: A DocC bug prevents the functions from resolving:-->
+<!--### XCTFail-->
+<!---->
+<!--- ``XCTFail(_:)-30at6``-->
+<!--- ``XCTFail(_:file:line:)-3ujuf``-->
+
+### Unimplemented Dependencies
+
+- ``XCTUnimplemented(_:placeholder:file:line:)-2jqzu``
+- ``XCTUnimplemented(_:)-3obl5``
+- <doc:UnimplementedOverloads>
+- ``XCTUnimplementedFailure``

--- a/Sources/XCTestDynamicOverlay/XCTUnimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/XCTUnimplemented.swift
@@ -1,80 +1,5 @@
-// MARK: (Parameters) -> Void
-
-/// Returns a closure that generates a failure when invoked.
-///
-/// - Parameter description: An optional description of the unimplemented closure, for inclusion in
-///   test results.
-/// - Returns: A closure that generates a failure when invoked.
-@_disfavoredOverload
-public func XCTUnimplemented(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable () -> Void {
-  return {
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A) -> Void {
-  return { _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B) -> Void {
-  return { _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B, C>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C) -> Void {
-  return { _, _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B, C, D>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D) -> Void {
-  return { _, _, _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B, C, D, E>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D, E) -> Void {
-  return { _, _, _, _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
 // MARK: (Parameters) -> Result
 
-/// Returns a closure that generates a failure when invoked.
-///
-/// - Parameters:
-///   - description: An optional description of the unimplemented closure, for inclusion in test
-///     results.
-///   - placeholder: An optional placeholder value returned from the closure. If omitted, calling
-///     the closure will fatal error instead.
-/// - Returns: A closure that generates a failure when invoked.
 @_disfavoredOverload
 public func XCTUnimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
@@ -85,7 +10,7 @@ public func XCTUnimplemented<Result>(
   return {
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -101,7 +26,7 @@ public func XCTUnimplemented<A, Result>(
   return { _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -117,7 +42,7 @@ public func XCTUnimplemented<A, B, Result>(
   return { _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -133,7 +58,7 @@ public func XCTUnimplemented<A, B, C, Result>(
   return { _, _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -149,7 +74,7 @@ public func XCTUnimplemented<A, B, C, D, Result>(
   return { _, _, _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -165,7 +90,7 @@ public func XCTUnimplemented<A, B, C, D, E, Result>(
   return { _, _, _, _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -233,68 +158,6 @@ public func XCTUnimplemented<A, B, C, D, E, Result>(
   }
 }
 
-// MARK: (Parameters) async -> Void
-
-@_disfavoredOverload
-public func XCTUnimplemented(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable () async -> Void {
-  return {
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A) async -> Void {
-  return { _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B) async -> Void {
-  return { _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B, C>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C) async -> Void {
-  return { _, _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B, C, D>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D) async -> Void {
-  return { _, _, _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
-@_disfavoredOverload
-public func XCTUnimplemented<A, B, C, D, E>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D, E) async -> Void {
-  return { _, _, _, _, _ in
-    let description = description()
-    XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-  }
-}
-
 // MARK: (Parameters) async -> Result
 
 @_disfavoredOverload
@@ -307,12 +170,21 @@ public func XCTUnimplemented<Result>(
   return {
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
 }
 
+/// Returns a closure that generates a failure when invoked.
+///
+/// - Parameters:
+///   - description: An optional description of the unimplemented closure, for inclusion in test
+///     results.
+///   - placeholder: An optional placeholder value returned from the closure. If omitted and a
+///     default value (like `()` for `Void`) cannot be returned, calling the closure will fatal
+///     error instead.
+/// - Returns: A closure that generates a failure when invoked.
 @_disfavoredOverload
 public func XCTUnimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
@@ -323,7 +195,7 @@ public func XCTUnimplemented<A, Result>(
   return { _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -339,7 +211,7 @@ public func XCTUnimplemented<A, B, Result>(
   return { _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -355,7 +227,7 @@ public func XCTUnimplemented<A, B, C, Result>(
   return { _, _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -371,7 +243,7 @@ public func XCTUnimplemented<A, B, C, D, Result>(
   return { _, _, _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -387,7 +259,7 @@ public func XCTUnimplemented<A, B, C, D, E, Result>(
   return { _, _, _, _, _ in
     let description = description()
     XCTFail("Unimplemented\(description.isEmpty ? "" : ": \(description)")")
-    guard let placeholder = placeholder()
+    guard let placeholder = placeholder() ?? _generatePlaceholder()
     else { _unimplementedFatalError(description, file: file, line: line) }
     return placeholder
   }
@@ -405,6 +277,11 @@ public func XCTUnimplemented<Result>(
   }
 }
 
+/// Returns a closure that generates a failure when invoked.
+///
+/// - Parameter description: An optional description of the unimplemented closure, for inclusion in
+///   test results.
+/// - Returns: A closure that generates a failure and throws an error when invoked.
 public func XCTUnimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = ""
 ) -> @Sendable (A) async throws -> Result {
@@ -455,8 +332,21 @@ public func XCTUnimplemented<A, B, C, D, E, Result>(
   }
 }
 
+/// An error thrown from ``XCTUnimplemented(_:)-3obl5``.
 public struct XCTUnimplementedFailure: Error {
   public let description: String
+}
+
+private func _generatePlaceholder<Result>() -> Result? {
+  if Result.self == Void.self {
+    return () as? Result
+  }
+  if
+    let result = (Witness<Result>.self as? AnyRangeReplaceableCollection.Type)?.empty() as? Result
+  {
+    return result
+  }
+  return nil
 }
 
 private func _unimplementedFatalError(_ message: String, file: StaticString, line: UInt) -> Never {
@@ -469,4 +359,14 @@ private func _unimplementedFatalError(_ message: String, file: StaticString, lin
     file: file,
     line: line
   )
+}
+
+protocol AnyRangeReplaceableCollection {
+  static func empty() -> Any
+}
+private enum Witness<Value> {}
+extension Witness: AnyRangeReplaceableCollection where Value: RangeReplaceableCollection {
+  static func empty() -> Any {
+    Value()
+  }
 }

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -5,85 +5,32 @@ func MyXCTFail(_ message: String) {
 }
 
 struct Client {
-  var p00: () -> Void
-  var p01: () -> Int
-  var p02: () throws -> Int
-  var p03: () async -> Void
-  var p04: () async -> Int
-  var p05: () async throws -> Int
-  var p06: (Int) -> Void
-  var p07: (Int) -> Int
-  var p08: (Int) throws -> Int
-  var p09: (Int) async -> Void
-  var p10: (Int) async -> Int
-  var p11: (Int) async throws -> Int
-  var p12: (Int, Int) -> Void
-  var p13: (Int, Int) -> Int
-  var p14: (Int, Int) throws -> Int
-  var p15: (Int, Int) async -> Void
-  var p16: (Int, Int) async -> Int
-  var p17: (Int, Int) async throws -> Int
-  var p18: (Int, Int, Int) -> Void
-  var p19: (Int, Int, Int) -> Int
-  var p20: (Int, Int, Int) throws -> Int
-  var p21: (Int, Int, Int) async -> Void
-  var p22: (Int, Int, Int) async -> Int
-  var p23: (Int, Int, Int) async throws -> Int
-  var p24: (Int, Int, Int, Int) -> Void
-  var p25: (Int, Int, Int, Int) -> Int
-  var p26: (Int, Int, Int, Int) throws -> Int
-  var p27: (Int, Int, Int, Int) async -> Void
-  var p28: (Int, Int, Int, Int) async -> Int
-  var p29: (Int, Int, Int, Int) async throws -> Int
-  var p30: (Int, Int, Int, Int, Int) -> Void
-  var p31: (Int, Int, Int, Int, Int) -> Int
-  var p32: (Int, Int, Int, Int, Int) throws -> Int
-  var p33: (Int, Int, Int, Int, Int) async -> Void
-  var p34: (Int, Int, Int, Int, Int) async -> Int
-  var p35: (Int, Int, Int, Int, Int) async throws -> Int
+  var p00: () -> Int
+  var p01: () throws -> Int
+  var p02: () async -> Int
+  var p03: () async throws -> Int
+  var p04: (Int) -> Int
+  var p05: (Int) throws -> Int
+  var p06: (Int) async -> Int
+  var p07: (Int) async throws -> Int
+  var p08: (Int, Int) -> Int
+  var p09: (Int, Int) throws -> Int
+  var p10: (Int, Int) async -> Int
+  var p11: (Int, Int) async throws -> Int
+  var p12: (Int, Int, Int) -> Int
+  var p13: (Int, Int, Int) throws -> Int
+  var p14: (Int, Int, Int) async -> Int
+  var p15: (Int, Int, Int) async throws -> Int
+  var p16: (Int, Int, Int, Int) -> Int
+  var p17: (Int, Int, Int, Int) throws -> Int
+  var p18: (Int, Int, Int, Int) async -> Int
+  var p19: (Int, Int, Int, Int) async throws -> Int
+  var p20: (Int, Int, Int, Int, Int) -> Int
+  var p21: (Int, Int, Int, Int, Int) throws -> Int
+  var p22: (Int, Int, Int, Int, Int) async -> Int
+  var p23: (Int, Int, Int, Int, Int) async throws -> Int
 
-  static var unimplementedA: Self {
-    Self(
-      p00: XCTUnimplemented("\(Self.self).p00"),
-      p01: XCTUnimplemented("\(Self.self).p01", placeholder: 42),
-      p02: XCTUnimplemented("\(Self.self).p02"),
-      p03: XCTUnimplemented("\(Self.self).p03"),
-      p04: XCTUnimplemented("\(Self.self).p04", placeholder: 42),
-      p05: XCTUnimplemented("\(Self.self).p05"),
-      p06: XCTUnimplemented("\(Self.self).p06"),
-      p07: XCTUnimplemented("\(Self.self).p07", placeholder: 42),
-      p08: XCTUnimplemented("\(Self.self).p08"),
-      p09: XCTUnimplemented("\(Self.self).p09"),
-      p10: XCTUnimplemented("\(Self.self).p10", placeholder: 42),
-      p11: XCTUnimplemented("\(Self.self).p11"),
-      p12: XCTUnimplemented("\(Self.self).p12"),
-      p13: XCTUnimplemented("\(Self.self).p13", placeholder: 42),
-      p14: XCTUnimplemented("\(Self.self).p14"),
-      p15: XCTUnimplemented("\(Self.self).p15"),
-      p16: XCTUnimplemented("\(Self.self).p16", placeholder: 42),
-      p17: XCTUnimplemented("\(Self.self).p17"),
-      p18: XCTUnimplemented("\(Self.self).p18"),
-      p19: XCTUnimplemented("\(Self.self).p19", placeholder: 42),
-      p20: XCTUnimplemented("\(Self.self).p20"),
-      p21: XCTUnimplemented("\(Self.self).p21"),
-      p22: XCTUnimplemented("\(Self.self).p22", placeholder: 42),
-      p23: XCTUnimplemented("\(Self.self).p23"),
-      p24: XCTUnimplemented("\(Self.self).p24"),
-      p25: XCTUnimplemented("\(Self.self).p25", placeholder: 42),
-      p26: XCTUnimplemented("\(Self.self).p26"),
-      p27: XCTUnimplemented("\(Self.self).p27"),
-      p28: XCTUnimplemented("\(Self.self).p28", placeholder: 42),
-      p29: XCTUnimplemented("\(Self.self).p29"),
-      p30: XCTUnimplemented("\(Self.self).p30"),
-      p31: XCTUnimplemented("\(Self.self).p31", placeholder: 42),
-      p32: XCTUnimplemented("\(Self.self).p32"),
-      p33: XCTUnimplemented("\(Self.self).p33"),
-      p34: XCTUnimplemented("\(Self.self).p34", placeholder: 42),
-      p35: XCTUnimplemented("\(Self.self).p35")
-    )
-  }
-
-  static var unimplementedB: Self {
+  static var unimplemented: Self {
     Self(
       p00: XCTUnimplemented("\(Self.self).p00"),
       p01: XCTUnimplemented("\(Self.self).p01"),
@@ -108,19 +55,7 @@ struct Client {
       p20: XCTUnimplemented("\(Self.self).p20"),
       p21: XCTUnimplemented("\(Self.self).p21"),
       p22: XCTUnimplemented("\(Self.self).p22"),
-      p23: XCTUnimplemented("\(Self.self).p23"),
-      p24: XCTUnimplemented("\(Self.self).p24"),
-      p25: XCTUnimplemented("\(Self.self).p25"),
-      p26: XCTUnimplemented("\(Self.self).p26"),
-      p27: XCTUnimplemented("\(Self.self).p27"),
-      p28: XCTUnimplemented("\(Self.self).p28"),
-      p29: XCTUnimplemented("\(Self.self).p29"),
-      p30: XCTUnimplemented("\(Self.self).p30"),
-      p31: XCTUnimplemented("\(Self.self).p31"),
-      p32: XCTUnimplemented("\(Self.self).p32"),
-      p33: XCTUnimplemented("\(Self.self).p33"),
-      p34: XCTUnimplemented("\(Self.self).p34"),
-      p35: XCTUnimplemented("\(Self.self).p35")
+      p23: XCTUnimplemented("\(Self.self).p23")
     )
   }
 }

--- a/Tests/XCTestDynamicOverlayTests/XCTestDynamicOverlayTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTestDynamicOverlayTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 final class XCTestDynamicOverlayTests: XCTestCase {
-  func testXCTFail() {
+  func testXCTFail() async throws {
     MyXCTFail("This is expected to fail!")
   }
 }


### PR DESCRIPTION
Was investigating why TCA dependencies fail to compile in DocC and decided to sketch out some docs for this library.

While hiding away the overloads I realized we don't need the `Void`-returning ones. We can just check `Result` dynamically.