### PR TITLE
Fix infinite loop

### DIFF
--- a/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
@@ -39,6 +39,5 @@ func runtimeWarning(
         to: ((OSLogType, UnsafeRawPointer, OSLog, StaticString, [CVarArg]) -> Void).self
       )(.fault, rw.dso, rw.log, message, args())
     }
-    XCTFail(String(format: "\(message)", arguments: args()))
   #endif
 }

--- a/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
@@ -32,12 +32,11 @@ func runtimeWarning(
   _ args: @autoclosure () -> [CVarArg] = []
 ) {
   #if DEBUG && canImport(os)
-    let message = message()
     if !_XCTIsTesting {
       unsafeBitCast(
         os_log as (OSLogType, UnsafeRawPointer, OSLog, StaticString, CVarArg...) -> Void,
         to: ((OSLogType, UnsafeRawPointer, OSLog, StaticString, [CVarArg]) -> Void).self
-      )(.fault, rw.dso, rw.log, message, args())
+      )(.fault, rw.dso, rw.log, message(), args())
     }
   #endif
 }


### PR DESCRIPTION
I copy-pasted the runtime warning code from TCA, which calls XCTFail from this library. We just should omit that recursive call entirely.

Fixes #18.
