### PR TITLE
Make `_XCTIsTesting` check a bit more robust

### DIFF
--- a/Sources/XCTestDynamicOverlay/XCTIsTesting.swift
+++ b/Sources/XCTestDynamicOverlay/XCTIsTesting.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 public let _XCTIsTesting: Bool = {
-  guard let path = ProcessInfo.processInfo.arguments.first
-  else { return false }
-
-  let url = URL(fileURLWithPath: path)
-  return url.lastPathComponent == "xctest" || url.pathExtension == "xctest"
+  ProcessInfo.processInfo.arguments.first
+    .flatMap(URL.init(fileURLWithPath:))
+    .map { $0.lastPathComponent == "xctest" || $0.pathExtension == "xctest" }
+  ?? ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
 }()

--- a/Sources/XCTestDynamicOverlay/XCTIsTesting.swift
+++ b/Sources/XCTestDynamicOverlay/XCTIsTesting.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 public let _XCTIsTesting: Bool = {
-  ProcessInfo.processInfo.arguments.first
-    .flatMap(URL.init(fileURLWithPath:))
-    .map { $0.lastPathComponent == "xctest" || $0.pathExtension == "xctest" }
-  ?? ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
+  ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
+    || ProcessInfo.processInfo.arguments.first
+      .flatMap(URL.init(fileURLWithPath:))
+      .map { $0.lastPathComponent == "xctest" || $0.pathExtension == "xctest" }
+      ?? false
 }()


### PR DESCRIPTION
The current check works fine for SPM packages, via Xcode, via `swift test`, and on Apple and non-Apple platforms, but it doesn't work for app hosts, which appear to configure the test runner via the environment.