### PR TITLE
Add `if !os(WASI)` for SwiftWasm

### DIFF
--- a/Sources/XCTestDynamicOverlay/XCTIsTesting.swift
+++ b/Sources/XCTestDynamicOverlay/XCTIsTesting.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if !os(WASI)
 public let _XCTIsTesting: Bool = {
   ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
     || ProcessInfo.processInfo.arguments.first
@@ -7,3 +8,4 @@ public let _XCTIsTesting: Bool = {
       .map { $0.lastPathComponent == "xctest" || $0.pathExtension == "xctest" }
       ?? false
 }()
+#endif


### PR DESCRIPTION
This PR adds `if !os(WASI)` for the scopes where some of the Foundation classes don't work in SwiftWasm.

[Porting code from other platforms - Swift and WebAssembly](https://book.swiftwasm.org/getting-started/porting.html#swift-foundation-and-dispatch)

This fix is mainly for allowing CustomDump to work correctly, which I will also open the related pull request soon.