### PR TITLE
Support more generated placeholder types

### DIFF
--- a/Sources/XCTestDynamicOverlay/Internal/DefaultInitializable.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/DefaultInitializable.swift
@@ -1,0 +1,44 @@
+protocol _DefaultInitializable {
+  init()
+}
+
+extension Array: _DefaultInitializable {}
+extension Bool: _DefaultInitializable {}
+extension Character: _DefaultInitializable { init() { self.init(" ") } }
+extension Dictionary: _DefaultInitializable {}
+extension Double: _DefaultInitializable {}
+extension Float: _DefaultInitializable {}
+extension Int: _DefaultInitializable {}
+extension Int8: _DefaultInitializable {}
+extension Int16: _DefaultInitializable {}
+extension Int32: _DefaultInitializable {}
+extension Int64: _DefaultInitializable {}
+extension Set: _DefaultInitializable {}
+extension String: _DefaultInitializable {}
+extension Substring: _DefaultInitializable {}
+extension UInt: _DefaultInitializable {}
+extension UInt8: _DefaultInitializable {}
+extension UInt16: _DefaultInitializable {}
+extension UInt32: _DefaultInitializable {}
+extension UInt64: _DefaultInitializable {}
+
+extension AsyncStream: _DefaultInitializable {
+  init() { self.init { $0.finish() } }
+}
+
+extension AsyncThrowingStream: _DefaultInitializable where Failure == Error {
+  init() { self.init { $0.finish(throwing: CancellationError()) } }
+}
+
+#if canImport(Foundation)
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension Data: _DefaultInitializable {}
+extension Date: _DefaultInitializable {}
+extension Decimal: _DefaultInitializable {}
+extension UUID: _DefaultInitializable {}
+extension URL: _DefaultInitializable { init() { self.init(string: "/")! } }
+#endif

--- a/Sources/XCTestDynamicOverlay/Internal/GeneratePlaceholder.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/GeneratePlaceholder.swift
@@ -1,0 +1,20 @@
+func _generatePlaceholder<Result>() -> Result? {
+  if Result.self == Void.self {
+    return () as? Result
+  }
+  if let result = (Witness<Result>.self as? AnyRangeReplaceableCollection.Type)?.empty() as? Result {
+    return result
+  }
+  return nil
+}
+
+protocol AnyRangeReplaceableCollection {
+  static func empty() -> Any
+}
+
+enum Witness<Value> {}
+extension Witness: AnyRangeReplaceableCollection where Value: RangeReplaceableCollection {
+  static func empty() -> Any {
+    Value()
+  }
+}

--- a/Sources/XCTestDynamicOverlay/Internal/GeneratePlaceholder.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/GeneratePlaceholder.swift
@@ -1,20 +1,157 @@
-func _generatePlaceholder<Result>() -> Result? {
+extension _DefaultInitializable { fileprivate static var placeholder: Self { Self() } }
+extension AdditiveArithmetic { fileprivate static var placeholder: Self { .zero } }
+extension ExpressibleByArrayLiteral { fileprivate static var placeholder: Self { [] } }
+extension ExpressibleByBooleanLiteral { fileprivate static var placeholder: Self { false } }
+extension ExpressibleByDictionaryLiteral { fileprivate static var placeholder: Self { [:] } }
+extension ExpressibleByFloatLiteral { fileprivate static var placeholder: Self { 0.0 } }
+extension ExpressibleByIntegerLiteral { fileprivate static var placeholder: Self { 0 } }
+extension ExpressibleByUnicodeScalarLiteral { fileprivate static var placeholder: Self { " " } }
+extension RangeReplaceableCollection { fileprivate static var placeholder: Self { Self() } }
+
+#if swift(>=5.7)
+
+private func _placeholder<Result>() -> Result? {
+  switch Result.self {
+  case let type as _DefaultInitializable.Type: return type.placeholder as? Result
+  case is Void.Type: return () as? Result
+  case let type as any RangeReplaceableCollection.Type: return type.placeholder as? Result
+  case let type as any AdditiveArithmetic.Type: return type.placeholder as? Result
+  case let type as any ExpressibleByArrayLiteral.Type: return type.placeholder as? Result
+  case let type as any ExpressibleByBooleanLiteral.Type: return type.placeholder as? Result
+  case let type as any ExpressibleByDictionaryLiteral.Type: return type.placeholder as? Result
+  case let type as any ExpressibleByFloatLiteral.Type: return type.placeholder as? Result
+  case let type as any ExpressibleByIntegerLiteral.Type: return type.placeholder as? Result
+  case let type as any ExpressibleByUnicodeScalarLiteral.Type: return type.placeholder as? Result
+  default: return nil
+  }
+}
+
+private func _rawRepresentable<Result>() -> Result? {
+  func posiblePlaceholder<T: RawRepresentable>(for type: T.Type) -> T? {
+    (_placeholder() as T.RawValue?).flatMap(T.init(rawValue:))
+  }
+
+  return (Result.self as? any RawRepresentable.Type).flatMap {
+    posiblePlaceholder(for: $0) as? Result
+  }
+}
+
+private func _caseIterable<Result>() -> Result? {
+  func firstCase<T: CaseIterable>(for type: T.Type) -> Result? {
+    T.allCases.first as? Result
+  }
+
+  return (Result.self as? any CaseIterable.Type).flatMap {
+    firstCase(for: $0)
+  }
+}
+
+#else
+
+private func _placeholder<Result>() -> Result? {
+  if let result = (Result.self as? _DefaultInitializable.Type)?.placeholder {
+    return result as? Result
+  }
+
   if Result.self == Void.self {
     return () as? Result
   }
-  if let result = (Witness<Result>.self as? AnyRangeReplaceableCollection.Type)?.empty() as? Result {
+
+  switch Witness<Result>.self {
+  case let type as AnyRangeReplaceableCollection.Type: return type.placeholder as? Result
+  case let type as AnyAdditiveArithmetic.Type: return type.placeholder as? Result
+  case let type as AnyExpressibleByArrayLiteral.Type: return type.placeholder as? Result
+  case let type as AnyExpressibleByBooleanLiteral.Type: return type.placeholder as? Result
+  case let type as AnyExpressibleByDictionaryLiteral.Type: return type.placeholder as? Result
+  case let type as AnyExpressibleByFloatLiteral.Type: return type.placeholder as? Result
+  case let type as AnyExpressibleByIntegerLiteral.Type: return type.placeholder as? Result
+  case let type as AnyExpressibleByUnicodeScalarLiteral.Type: return type.placeholder as? Result
+  default: return nil
+  }
+}
+
+private func _rawRepresentable<Result>() -> Result? {
+  (Witness<Result>.self as? AnyRawRepresentable.Type).flatMap {
+    $0.possiblePlaceholder as? Result
+  }
+}
+
+private func _caseIterable<Result>() -> Result? {
+  (Witness<Result>.self as? AnyCaseIterable.Type).flatMap {
+    $0.firstCase as? Result
+  }
+}
+
+private enum Witness<Value> {}
+private protocol AnyAdditiveArithmetic { static var placeholder: Any { get } }
+extension Witness: AnyAdditiveArithmetic where Value: AdditiveArithmetic {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyExpressibleByArrayLiteral { static var placeholder: Any { get } }
+extension Witness: AnyExpressibleByArrayLiteral where Value: ExpressibleByArrayLiteral {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyExpressibleByBooleanLiteral { static var placeholder: Any { get } }
+extension Witness: AnyExpressibleByBooleanLiteral where Value: ExpressibleByBooleanLiteral {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyExpressibleByDictionaryLiteral { static var placeholder: Any { get } }
+extension Witness: AnyExpressibleByDictionaryLiteral where Value: ExpressibleByDictionaryLiteral {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyExpressibleByFloatLiteral { static var placeholder: Any { get } }
+extension Witness: AnyExpressibleByFloatLiteral where Value: ExpressibleByFloatLiteral {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyExpressibleByIntegerLiteral { static var placeholder: Any { get } }
+extension Witness: AnyExpressibleByIntegerLiteral where Value: ExpressibleByIntegerLiteral {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyExpressibleByUnicodeScalarLiteral { static var placeholder: Any { get } }
+extension Witness: AnyExpressibleByUnicodeScalarLiteral
+where Value: ExpressibleByUnicodeScalarLiteral {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyRangeReplaceableCollection { static var placeholder: Any { get } }
+extension Witness: AnyRangeReplaceableCollection where Value: RangeReplaceableCollection {
+  fileprivate static var placeholder: Any { Value.placeholder }
+}
+
+private protocol AnyRawRepresentable { static var possiblePlaceholder: Any? { get } }
+extension Witness: AnyRawRepresentable where Value: RawRepresentable {
+  fileprivate static var possiblePlaceholder: Any? {
+    (_placeholder() as Value.RawValue?).flatMap(Value.init(rawValue:))
+  }
+}
+
+private protocol AnyCaseIterable { static var firstCase: Any? { get } }
+extension Witness: AnyCaseIterable where Value: CaseIterable {
+  fileprivate static var firstCase: Any? {
+    Value.allCases.first
+  }
+}
+
+#endif
+
+func _generatePlaceholder<Result>() -> Result? {
+  if let result = _placeholder() as Result? {
     return result
   }
-  return nil
-}
 
-protocol AnyRangeReplaceableCollection {
-  static func empty() -> Any
-}
-
-enum Witness<Value> {}
-extension Witness: AnyRangeReplaceableCollection where Value: RangeReplaceableCollection {
-  static func empty() -> Any {
-    Value()
+  if let result = _rawRepresentable() as Result? {
+    return result
   }
+
+  if let result = _caseIterable() as Result? {
+    return result
+  }
+
+  return nil
 }

--- a/Sources/XCTestDynamicOverlay/Unimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/Unimplemented.swift
@@ -543,17 +543,6 @@ func _fail(_ description: String, _ parameters: Any?, fileID: StaticString, line
   )
 }
 
-func _generatePlaceholder<Result>() -> Result? {
-  if Result.self == Void.self {
-    return () as? Result
-  }
-  if let result = (Witness<Result>.self as? AnyRangeReplaceableCollection.Type)?.empty() as? Result
-  {
-    return result
-  }
-  return nil
-}
-
 func _unimplementedFatalError(_ message: String, file: StaticString, line: UInt) -> Never {
   fatalError(
     """
@@ -564,14 +553,4 @@ func _unimplementedFatalError(_ message: String, file: StaticString, line: UInt)
     file: file,
     line: line
   )
-}
-
-protocol AnyRangeReplaceableCollection {
-  static func empty() -> Any
-}
-enum Witness<Value> {}
-extension Witness: AnyRangeReplaceableCollection where Value: RangeReplaceableCollection {
-  static func empty() -> Any {
-    Value()
-  }
 }

--- a/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
@@ -1,0 +1,66 @@
+#if !os(Linux)
+import Foundation
+import XCTest
+import XCTestDynamicOverlay
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+final class GeneratePlaceholderTests: XCTestCase {
+  func testShouldGeneratePlaceholder() async throws {
+    let bool: () -> Bool = unimplemented("bool")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: bool), false)
+    let double: () -> Double = unimplemented("double")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: double), 0.0)
+    let int: () -> Int = unimplemented("int")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: int), 0)
+    let string: () -> String = unimplemented("string")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: string), "")
+
+    let array: () -> [Int] = unimplemented("array")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: array), [Int]())
+    let dictionary: () -> [String: Int] = unimplemented("dictionary")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: dictionary), [String: Int]())
+    let set: () -> Set<Int> = unimplemented("set")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: set), Set<Int>())
+
+    let stream: () -> AsyncStream<Int> = unimplemented("stream")
+    for await _ in XCTExpectFailure(failingBlock: stream) {
+      XCTFail("Stream should be finished")
+    }
+
+    let throwingStream: () -> AsyncThrowingStream<Int, Error> = unimplemented("throwingStream")
+    let result = await Task {
+      try await XCTExpectFailure(failingBlock: throwingStream).first(where: { _ in true })
+    }.result
+    XCTAssertThrowsError(try result.get()) { XCTAssertTrue($0 is CancellationError) }
+
+    let date: () -> Date = unimplemented("date")
+    XCTAssertNotNil(XCTExpectFailure(failingBlock: date))
+    let url: () -> URL = unimplemented("url")
+    XCTAssertNotNil(XCTExpectFailure(failingBlock: url))
+    let uuid: () -> UUID = unimplemented("uuid")
+    XCTAssertNotNil(XCTExpectFailure(failingBlock: uuid))
+
+    let enumCaseIterable: () -> EnumCaseIterable = unimplemented("enumCaseIterable")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: enumCaseIterable), .first)
+    let enumInt: () -> EnumInt = unimplemented("enumInt")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: enumInt), .zero)
+    let taggedInt: () -> Tagged<Self, Int> = unimplemented("taggedInt")
+    XCTAssertEqual(XCTExpectFailure(failingBlock: taggedInt), 0)
+  }
+}
+
+enum EnumInt: Int { case zero, one, two }
+
+enum EnumCaseIterable: CaseIterable { case first, second, third }
+
+struct Tagged<Tag, RawValue: Equatable>: Equatable { var rawValue: RawValue }
+extension Tagged: ExpressibleByIntegerLiteral where RawValue: ExpressibleByIntegerLiteral {
+  typealias IntegerLiteralType = RawValue.IntegerLiteralType
+  init(integerLiteral value: IntegerLiteralType) {
+    self.init(rawValue: RawValue(integerLiteral: value))
+  }
+}
+#endif


### PR DESCRIPTION
This PR allows `_generatePlaceholder()` to work with additional types. This is more of a proof of concept and I think it needs to be reworked after defining the desired behaviour of `_generatePlaceholder()`. I'm not attached to any of the naming or approach taken. I've structured things in a way that will hopefully make it easy to understand and discuss. 

Some notes:

There are a few ways of generating a placeholder:
- Identifying a know type and returning a placeholder value
```swift
if Result.self == Void.self { return () as? Result }
```
- Using an existing protocol that has a requirement that provides a placeholder value
```swift
(Result.self as? any RangeReplaceableCollection.Type)?.init() as? Result
(Result.self as? any AdditiveArithmetic.Type)?.zero as? Result
```
- Defining a new protocol that has a requirement that provides a placeholder value
```swift
protocol _DefaultInitializable {
  init()
}
extension UUID: _DefaultInitializable {}
```

All three are used in this PR:
- First trying `_DefaultInitializable`
- Then checking for `Void`
- And finally checking a bunch of other protocols

There is a bit of overlap and lots of the types conforming to `_DefaultInitializable` would work with `RangeReplaceableCollection`, `AdditiveArithmetic` etc.. 

`_DefaultInitializable` would probably be needed regardless so maybe try catch as much as possible there before trying a bunch of other protocols. The other protocols are more to generate non standard types eg: `Tagged<Self, Int>`.

An attempt is also made to use `RawRepresentable` and `CaseIterable`. These aren't guaranteed to work but adds a little more coverage.

`static var placeholder` is more used as a cognitive helper. `AdditiveArithmetic.zero` and `RangeReplaceableCollection.init()` both become `Type.placeholder`. `defaultValue` works too but chose `placeholder` to match the function name. 

Runtime metadata could be used to support more types. Didn't want to head down that path until further discussion though. 

Could also mark some stuff with `@_spi(Internal)`