### PR TITLE
Support `unimplemented` as a "hole" for autoclosures

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ If you are disciplined about injecting dependencies, you probably have a lot of 
 
 ```swift
 class LoginViewModel: ObservableObject {
-  ...
+  // ...
 
   init(analytics: AnalyticsClient) {
-    ...
+    // ...
   }
 
-  ...
+  // ...
 }
 ```
 
@@ -79,7 +79,7 @@ func testLogin() {
     analytics: .test { events.append($0) }
   )
 
-  ...
+  // ...
 
   XCTAssertEqual(events, [.init(name: "Login Success")])
 }
@@ -109,7 +109,7 @@ func testValidation() {
     analytics: .unimplemented
   )
 
-  ...
+  // ...
 }
 ```
 

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/GettingStarted.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/GettingStarted.md
@@ -23,13 +23,13 @@ If you are disciplined about injecting dependencies, you probably have a lot of 
 
 ```swift
 class LoginViewModel: ObservableObject {
-  ...
+  // ...
 
   init(analytics: AnalyticsClient) {
-    ...
+    // ...
   }
 
-  ...
+  // ...
 }
 ```
 
@@ -42,7 +42,7 @@ func testLogin() {
     analytics: .test { events.append($0) }
   )
 
-  ...
+  // ...
 
   XCTAssertEqual(events, [.init(name: "Login Success")])
 }
@@ -72,7 +72,7 @@ func testValidation() {
     analytics: .unimplemented
   )
 
-  ...
+  // ...
 }
 ```
 

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/UnimplementedPlaceholder.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/UnimplementedPlaceholder.md
@@ -4,6 +4,8 @@
 
 ### Overloads
 
+- ``unimplemented(_:placeholder:fileID:line:)-9tt2k``
+- ``unimplemented(_:file:fileID:line:)-74vrh``
 - ``unimplemented(_:placeholder:fileID:line:)-63r9c``
 - ``unimplemented(_:file:fileID:line:)-7naoc``
 - ``unimplemented(_:placeholder:fileID:line:)-1d7ul``

--- a/Sources/XCTestDynamicOverlay/Unimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/Unimplemented.swift
@@ -1,6 +1,5 @@
 // MARK: (Parameters) -> Result
 
-@_disfavoredOverload
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -13,7 +12,6 @@ public func unimplemented<Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -30,6 +28,30 @@ public func unimplemented<Result>(
 }
 
 @_disfavoredOverload
+public func unimplemented<Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  placeholder: @autoclosure @escaping @Sendable () -> Result,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> Result {
+  _fail(description(), nil, fileID: fileID, line: line)
+  return placeholder()
+}
+
+@_disfavoredOverload
+public func unimplemented<Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> Result {
+  let description = description()
+  _fail(description, nil, fileID: fileID, line: line)
+  guard let placeholder: Result = _generatePlaceholder()
+  else { _unimplementedFatalError(description, file: file, line: line) }
+  return placeholder
+}
+
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -42,7 +64,6 @@ public func unimplemented<A, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -58,7 +79,6 @@ public func unimplemented<A, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -71,7 +91,6 @@ public func unimplemented<A, B, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -87,7 +106,6 @@ public func unimplemented<A, B, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -100,7 +118,6 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -116,7 +133,6 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -129,7 +145,6 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -145,7 +160,6 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -158,7 +172,6 @@ public func unimplemented<A, B, C, D, E, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -250,7 +263,6 @@ public func unimplemented<A, B, C, D, E, Result>(
 
 // MARK: (Parameters) async -> Result
 
-@_disfavoredOverload
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -263,7 +275,6 @@ public func unimplemented<Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -288,7 +299,6 @@ public func unimplemented<Result>(
 ///     default value (like `()` for `Void`) cannot be returned, calling the closure will fatal
 ///     error instead.
 /// - Returns: A closure that generates a failure when invoked.
-@_disfavoredOverload
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -301,7 +311,6 @@ public func unimplemented<A, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -317,7 +326,6 @@ public func unimplemented<A, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -330,7 +338,6 @@ public func unimplemented<A, B, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -346,7 +353,6 @@ public func unimplemented<A, B, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -359,7 +365,6 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -375,7 +380,6 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -388,7 +392,6 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -404,7 +407,6 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -417,7 +419,6 @@ public func unimplemented<A, B, C, D, E, Result>(
   }
 }
 
-@_disfavoredOverload
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -69,3 +69,12 @@ let f02: (String, Int) -> Int = unimplemented("f02", placeholder: 42)
 let f03: (String, Int, Double) -> Int = unimplemented("f03", placeholder: 42)
 let f04: (String, Int, Double, [Int]) -> Int = unimplemented("f04", placeholder: 42)
 let f05: (String, Int, Double, [Int], User) -> Int = unimplemented("f05", placeholder: 42)
+
+private struct Autoclosing {
+  init(
+    _: @autoclosure () -> Int = unimplemented(),
+    _: @autoclosure () async -> Int = unimplemented(),
+    _: @autoclosure () throws -> Int = unimplemented(),
+    _: @autoclosure () async throws -> Int = unimplemented()
+  ) async {}
+}


### PR DESCRIPTION
This is an idea brought up by @tgrapperon. I had to remove a lot of `@_disfavoredOverload`s to get it to work, but I'm now wondering why they were there in the first place. Things seem to compile just fine without them.