### PR TITLE
Make XCTCurrentTestCase visible to SPI.

### DIFF
--- a/Sources/XCTestDynamicOverlay/Internal/XCTCurrentTestCase.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/XCTCurrentTestCase.swift
@@ -2,7 +2,7 @@
   #if canImport(ObjectiveC)
     import Foundation
 
-    var XCTCurrentTestCase: AnyObject? {
+    @_spi(CurrentTestCase) public var XCTCurrentTestCase: AnyObject? {
       guard
         let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
         let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,

--- a/Sources/XCTestDynamicOverlay/Internal/XCTCurrentTestCase.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/XCTCurrentTestCase.swift
@@ -19,12 +19,12 @@
       return currentTestCase
     }
   #else
-    var XCTCurrentTestCase: AnyObject? {
+    @_spi(CurrentTestCase) public var XCTCurrentTestCase: AnyObject? {
       nil
     }
   #endif
 #else
-  var XCTCurrentTestCase: AnyObject? {
+  @_spi(CurrentTestCase) public var XCTCurrentTestCase: AnyObject? {
     nil
   }
 #endif

--- a/Tests/XCTestDynamicOverlayTests/CurrentTestCaseTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/CurrentTestCaseTests.swift
@@ -1,0 +1,4 @@
+@_spi(CurrentTestCase) import XCTestDynamicOverlay
+
+// Make sure XCTCurrentTestCase is visible to SPI.
+private let currentTestCase = XCTCurrentTestCase


### PR DESCRIPTION
We need access to this to implement an XCTUnwrap helper for enums and case paths.