### PR TITLE
Show a warning when some failure is generated outside of a test by the host app.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ EXPECTED_STRING = This is expected to fail!
 EXPECTED = \033[31m\"$(EXPECTED_STRING)\"\033[0m
 
 test:
-	@TEST_FAILURE=true swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
+	@TEST_FAILURE=true swift build --build-tests \
+		&& swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
 		&& (echo "$(PASS) $(XCT_FAIL) was called with $(EXPECTED)" && exit) \
 		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ EXPECTED_STRING = This is expected to fail!
 EXPECTED = \033[31m\"$(EXPECTED_STRING)\"\033[0m
 
 test:
-	@TEST_FAILURE=true swift build --build-tests \
-		&& swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
+	@swift build --build-tests \
+		&& TEST_FAILURE=true swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
 		&& (echo "$(PASS) $(XCT_FAIL) was called with $(EXPECTED)" && exit) \
 		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
 

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -75,7 +75,7 @@
       // XCTesting is providing a default host app.
       return originalMessage
     }
-    
+
     if Thread.callStackSymbols.contains(where: { $0.range(of: "XCTestCore") != nil }) {
       // We are apparently performing a sync test
       return originalMessage
@@ -89,7 +89,7 @@
 
     let message = """
       Warning! This failure occurred while running tests hosted by the main app.
-      
+
       Testing using the main app as a host can lead to false positive test failures created by the \
       app accessing unimplemented values itself when it is spun up.
 

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -1,7 +1,7 @@
 #if DEBUG
-  #if canImport(ObjectiveC)
-    import Foundation
+  import Foundation
 
+  #if canImport(ObjectiveC)
     /// This function generates a failure immediately and unconditionally.
     ///
     /// Dynamically creates and records an `XCTIssue` under the hood that captures the source code

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -67,37 +67,43 @@
     public func XCTFail(_ message: String = "", file: StaticString, line: UInt) {}
   #endif
 
-func appendHostAppWarningIfNeeded(_ originalMessage: String) -> String {
-  guard _XCTIsTesting else { return originalMessage }
-  if Bundle.main.bundleIdentifier == "com.apple.dt.xctest.tool" {
-    // XCTesting is providing a default host app.
-    return originalMessage
-  }
-  if Thread.callStackSymbols.contains(where: { $0.range(of: "XCTestCore") != nil }) {
-    // We are apparently performing a sync test
-    return originalMessage
-  }
-  // TODO: Find a better heuristic. Maybe `Tests[]test`?
-  if Thread.callStackSymbols.contains(where: { $0.range(of: "Tests") != nil }) {
-    // We are apparently performing an async test
-    return originalMessage
-  }
+  func appendHostAppWarningIfNeeded(_ originalMessage: String) -> String {
+    guard _XCTIsTesting else { return originalMessage }
+    if Bundle.main.bundleIdentifier == "com.apple.dt.xctest.tool"  // Apple platforms
+      || Bundle.main.bundleIdentifier == nil  // Linux
+    {
+      // XCTesting is providing a default host app.
+      return originalMessage
+    }
+    if Thread.callStackSymbols.contains(where: { $0.range(of: "XCTestCore") != nil }) {
+      // We are apparently performing a sync test
+      return originalMessage
+    }
 
-  let message = """
-  Warning! This failure occurred while running tests hosted by the main app.
-  
-  When some `test` context is automatically inferred (like it's the case with "Dependencies") \
-  this can produce false positive test failures, as the app itself can load and access \
-  unimplemented values out of the scope of tests.
+    if Thread.callStackSymbols.contains(where: {
+      $0.range(of: ".Tests.{1,6}test.", options: .regularExpression) != nil
+    }) {
+      // We are apparently performing an async test.
+      // We're matching `_Tests` and `test_` on the same line separated by a few mangling symbols
+      return originalMessage
+    }
 
-    - Tests host: \(Bundle.main.bundleIdentifier ?? "Unknown")
-  
-  You can find more informations and workarounds in the "Testing/Testing Gotchas" section of \
-  `swift-dependencies`'s documentation.
-  """
-  
-  return [originalMessage, "", message].joined(separator: "\n")
-}
+    let message = """
+      Warning! This failure occurred while running tests hosted by the main app.
+
+      When some `test` context is automatically inferred (like it's the case with "Dependencies") \
+      this can produce false positive test failures, as the app itself can load and access \
+      unimplemented values out of the scope of individual tests.
+
+        - Tests host: \(Bundle.main.bundleIdentifier ?? "Unknown")
+
+      You can find more information and workarounds in the "Testing/Testing Gotchas" section of \
+      Dependencies' documentation at \
+      https://pointfreeco.github.io/swift-dependencies/main/documentation/dependencies/testing/.
+      """
+
+    return [originalMessage, "", message].joined(separator: "\n")
+  }
 
 #else
   /// This function generates a failure immediately and unconditionally.

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -103,34 +103,32 @@
     return [originalMessage, "", message].joined(separator: "\n")
   }
 
-private let testCaseCandidateRegex = #"(?<=\$s)\d{1,3}.*C(?=\d{1,3}test.*yy.*F)"#
-func testCaseSubclass(callStackSymbols: [String]) -> Any.Type? {
-  for frame in callStackSymbols {
-    var startIndex = frame.startIndex
-    while startIndex != frame.endIndex {
-      if let range = frame.range(
-        of: testCaseCandidateRegex,
-        options: .regularExpression,
-        range: startIndex..<frame.endIndex,
-        locale: nil
-      ) {
-        let candidate = _typeByName(String(frame[range]))
-        if
-          let nsCandidate = (candidate as? NSObject.Type),
-          let xcTestCase = NSClassFromString("XCTestCase"),
-          nsCandidate.isSubclass(of: xcTestCase)
-        {
-          return nsCandidate
+  private let testCaseCandidateRegex = #"(?<=\$s)\d{1,3}.*C(?=\d{1,3}test.*yy.*F)"#
+  func testCaseSubclass(callStackSymbols: [String]) -> Any.Type? {
+    for frame in callStackSymbols {
+      var startIndex = frame.startIndex
+      while startIndex != frame.endIndex {
+        if let range = frame.range(
+          of: testCaseCandidateRegex,
+          options: .regularExpression,
+          range: startIndex..<frame.endIndex,
+          locale: nil
+        ) {
+          let candidate = _typeByName(String(frame[range]))
+          if let nsCandidate = (candidate as? NSObject.Type),
+            let xcTestCase = NSClassFromString("XCTestCase"),
+            nsCandidate.isSubclass(of: xcTestCase)
+          {
+            return nsCandidate
+          }
+          startIndex = range.upperBound
+        } else {
+          break
         }
-        startIndex = range.upperBound
-      } else {
-        break
       }
     }
+    return nil
   }
-  return nil
-}
-
 
 #else
   /// This function generates a failure immediately and unconditionally.

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -81,10 +81,11 @@
     }
 
     if Thread.callStackSymbols.contains(where: {
-      $0.range(of: ".Tests.{1,6}test.", options: .regularExpression) != nil
+      $0.range(of: #"\$s\d{1,3}.*Tests.*C\d{1,3}test.*yy.*F"#, options: .regularExpression) != nil
     }) {
       // We are apparently performing an async test.
-      // We're matching `_Tests` and `test_` on the same line separated by a few mangling symbols
+      // We're matching a `() -> ()` function that starts with `test`, from a class that contains
+      // `Tests` in its name.
       return originalMessage
     }
 

--- a/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import XCTestDynamicOverlay
+
+final class HostAppCallStackTests: XCTestCase {
+  func testIsAbleToDetectT_est() {
+    XCTAssertEqual(
+      testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
+      ObjectIdentifier(HostAppCallStackTests.self)
+    )
+  }
+
+  func testIsAbleToDetectT_estAsync() async {
+    XCTAssertEqual(
+      testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
+      ObjectIdentifier(HostAppCallStackTests.self)
+    )
+  }
+}
+
+final class HostAppCallStackT_ests: XCTestCase {
+  func testIsAbleToDetectT_est() {
+    XCTAssertEqual(
+      testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
+      ObjectIdentifier(HostAppCallStackT_ests.self)
+    )
+  }
+
+  func testIsAbleToDetectT_estAsync() async {
+    XCTAssertEqual(
+      testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
+      ObjectIdentifier(HostAppCallStackT_ests.self)
+    )
+  }
+}

--- a/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
@@ -9,24 +9,34 @@ final class HostAppCallStackTests: XCTestCase {
     )
   }
 
-  func testIsAbleToDetectTestAsync() async {
+  func testIsAbleToDetectAsyncTest() async {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
   
-  func testIsAbleToDetectTestThrows() throws {
+  func testIsAbleToDetectThrowingTest() throws {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
   
-  func testIsAbleToDetectTestAsyncThrows() async throws {
+  func testIsAbleToDetectAsyncThrowingTest() async throws {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
+  
+  #if !os(Linux)
+  func testFailDoesNotAppendHostAppWarningFromATest() {
+    XCTExpectFailure {
+      XCTestDynamicOverlay.XCTFail("foo")
+    } issueMatcher: {
+      $0.compactDescription == "foo"
+    }
+  }
+  #endif
 }

--- a/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
@@ -2,33 +2,31 @@ import XCTest
 @testable import XCTestDynamicOverlay
 
 final class HostAppCallStackTests: XCTestCase {
-  func testIsAbleToDetectT_est() {
+  func testIsAbleToDetectTest() {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
 
-  func testIsAbleToDetectT_estAsync() async {
+  func testIsAbleToDetectTestAsync() async {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
-}
-
-final class HostAppCallStackT_ests: XCTestCase {
-  func testIsAbleToDetectT_est() {
+  
+  func testIsAbleToDetectTestThrows() throws {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
-      ObjectIdentifier(HostAppCallStackT_ests.self)
+      ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
-
-  func testIsAbleToDetectT_estAsync() async {
+  
+  func testIsAbleToDetectTestAsyncThrows() async throws {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
-      ObjectIdentifier(HostAppCallStackT_ests.self)
+      ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
 }

--- a/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/HostAppDetectionTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import XCTestDynamicOverlay
 
 final class HostAppCallStackTests: XCTestCase {
@@ -15,28 +16,28 @@ final class HostAppCallStackTests: XCTestCase {
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
-  
+
   func testIsAbleToDetectThrowingTest() throws {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
-  
+
   func testIsAbleToDetectAsyncThrowingTest() async throws {
     XCTAssertEqual(
       testCaseSubclass(callStackSymbols: Thread.callStackSymbols).map(ObjectIdentifier.init),
       ObjectIdentifier(HostAppCallStackTests.self)
     )
   }
-  
+
   #if !os(Linux)
-  func testFailDoesNotAppendHostAppWarningFromATest() {
-    XCTExpectFailure {
-      XCTestDynamicOverlay.XCTFail("foo")
-    } issueMatcher: {
-      $0.compactDescription == "foo"
+    func testFailDoesNotAppendHostAppWarningFromATest() {
+      XCTExpectFailure {
+        XCTestDynamicOverlay.XCTFail("foo")
+      } issueMatcher: {
+        $0.compactDescription == "foo"
+      }
     }
-  }
   #endif
 }


### PR DESCRIPTION
This PR appends a warning message to the original failure message if `XCTFail` is called from the host app, while testing, but outside of a test. 

It deduces that the failure is originating from the main hosting app by:
- Checking that we're indeed testing.
- Checking that the `bundleIdentifier` is not the default one provided by `XCTest` (i.e. we're hosting tests with the main app)
- Checking that the call stack doesn't contain test-related frames (i.e. we're not running a test)