### PR TITLE
Soften app host failure message

### DIFF
--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -76,13 +76,6 @@ import Foundation
       guard callStack.allSatisfy({ frame in !isTestFrame(frame) })
       else { return }
 
-      let displayName =
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
-        ?? Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
-        ?? "Unknown host application"
-
-      let bundleIdentifier = Bundle.main.bundleIdentifier ?? "Unknown bundle identifier"
-
       if !message.contains(where: \.isNewline) {
         message.append(" …")
       }
@@ -92,8 +85,8 @@ import Foundation
 
         
         ━━┉┅
-        Note: This failure was emitted from tests running in a host application \
-        (\(bundleIdentifier)).
+        Note: This failure was emitted from tests running in a host application\
+        \(Bundle.main.bundleIdentifier.map { " (\($0))" }).
 
         This can lead to false positives, where failures could have emitted from live application \
         code at launch time, and not from the current test.

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -92,14 +92,11 @@ import Foundation
 
         
         ━━┉┅
-        Note: This failure was emitted from tests running in a host application:
+        Note: This failure was emitted from tests running in a host application \
+        (\(bundleIdentifier)).
 
-          \(displayName) (\(bundleIdentifier))
-
-        This can lead to false positives, where failures (like this one) could have emitted from \
-        live application code at launch time, and not from the current test.
-
-        To avoid false positives, consider setting the test target's host application to "None."
+        This can lead to false positives, where failures could have emitted from live application \
+        code at launch time, and not from the current test.
 
         For more information (and workarounds), see "Testing gotchas":
 

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -90,22 +90,16 @@ import Foundation
       message.append(
         """
 
+        
+        ━━┉┅
+        Note: This failure was emitted from tests running in a host application:
 
-        ┏━━━━━━━━━━━━━━━━━┉┅
-        ┃ ⚠︎ Warning:
-        ┃
-        ┃ This failure was emitted from a host application outside the test stack.
-        ┃
-        ┃   Host application:
-        ┃     \(displayName) (\(bundleIdentifier))
-        ┃
-        ┃ The host application may have emitted this failure when it first launched,
-        ┃ outside this current test that happens to be running.
-        ┃
-        ┃ Consider setting the test target's host application to "None," or prevent
-        ┃ the host application from performing the code path that emits failure.
-        ┗━━━━━━━━━━━━━━━━━┉┅
-            ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
+          \(displayName) (\(bundleIdentifier))
+
+        This can lead to false positives, where failures (like this one) could have emitted from \
+        live application code at launch time, and not from the current test.
+
+        To avoid false positives, consider setting the test target's host application to "None."
 
         For more information (and workarounds), see "Testing gotchas":
 


### PR DESCRIPTION
The way we detect app hosts triggers more often than we expected, especially in async tests, so let's make it sound a bit more informational instead of a loud warning that makes the false positive sound more definitive.