### PR TITLE
Add some non-autoclosure placeholder overload

### DIFF
--- a/Sources/XCTestDynamicOverlay/Unimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/Unimplemented.swift
@@ -14,6 +14,18 @@ public func unimplemented<Result>(
 
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
+  placeholder: @escaping @Sendable () -> Result,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable () -> Result {
+  return {
+    _fail(description(), nil, fileID: fileID, line: line)
+    return placeholder()
+  }
+}
+
+public func unimplemented<Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
   fileID: StaticString = #fileID,
   line: UInt = #line


### PR DESCRIPTION
This should allow to "wrongly" define the placeholder of an unimplemented `() -> A` as `() -> A`. More explicitly:
```swift
struct S {
  var a: () -> String
}
S(a: unimplemented(placeholder: "X")) // and
S(a: unimplemented(placeholder: { "X" } ))
```
would behave the same. Right now the second line triggers a failure when we try to legitimately assign its value in a `withDependencies` block.
Hopefully this overloads doesn't create ambiguities. It also seems that this is the only one that needs to be implemented (AFAIK, `@autoclosure` excludes `async` and `throws`).
See https://pointfreecommunity.slack.com/archives/C04L2D0MNJH/p1676449096114709