### PR TITLE
Fix Swift warning

### DIFF
--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -86,7 +86,7 @@ import Foundation
 
         ━━┉┅
         Note: This failure was emitted from tests running in a host application\
-        \(Bundle.main.bundleIdentifier.map { " (\($0))" } ?? "").
+        \(String(describing: Bundle.main.bundleIdentifier.map { " (\($0))" })).
 
         This can lead to false positives, where failures could have emitted from live application \
         code at launch time, and not from the current test.


### PR DESCRIPTION
When using this library in a full Xcode project, I am getting the Swift warning on this line:

```
xctest-dynamic-overlay/Sources/XCTestDynamicOverlay/XCTFail.swift:89:11: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
```

I went ahead and fixed it using the Xcode suggestion, but not sure if you'd rather:

1. Provide a default value
2. Force unwrap `Bundle.main.bundleIdentifier`
3. Go with what I have here.

Or perhaps you don't care about the warning. Regardless, thought I'd give this PR a shot.

