### PR TITLE
Print warning in console when invoking XCFail from non-DEBUG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
-      run: make test
+      run: make test-linux-action
 
   wasm:
      name: SwiftWASM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
-      run: make test-linux-action
+      run: make test-linux
 
   wasm:
      name: SwiftWASM

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,19 @@ XCT_FAIL = \033[34mXCTFail\033[0m
 EXPECTED_STRING = This is expected to fail!
 EXPECTED = \033[31m\"$(EXPECTED_STRING)\"\033[0m
 
-test:
+test-debug:
 	@swift build --build-tests \
 		&& TEST_FAILURE=true swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
 		&& (echo "$(PASS) $(XCT_FAIL) was called with $(EXPECTED)" && exit) \
 		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
+
+test: test-debug
 	@swift test -c release | grep '⚠︎ Warning: This XCTFail was ignored' || exit 1
 
-test-linux-action:
-	@swift build --build-tests \
-		&& TEST_FAILURE=true swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
-		&& (echo "$(PASS) $(XCT_FAIL) was called with $(EXPECTED)" && exit) \
-		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
+test-linux: test-debug
 	@swift test -c release
 
-test-linux:
+test-linux-docker:
 	@docker run \
 		--rm \
 		-v "$(PWD):$(PWD)" \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ test:
 		&& TEST_FAILURE=true swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
 		&& (echo "$(PASS) $(XCT_FAIL) was called with $(EXPECTED)" && exit) \
 		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
+	@swift test -c release | grep '⚠︎ Warning: This XCTFail was ignored' || exit 1
 
 test-linux:
 	@docker run \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ test:
 		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
 	@swift test -c release | grep '⚠︎ Warning: This XCTFail was ignored' || exit 1
 
+test-linux-action:
+	@swift build --build-tests \
+		&& TEST_FAILURE=true swift test 2>&1 | grep '$(EXPECTED_STRING)' > /dev/null \
+		&& (echo "$(PASS) $(XCT_FAIL) was called with $(EXPECTED)" && exit) \
+		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
+	@swift test -c release
+
 test-linux:
 	@docker run \
 		--rm \

--- a/README.md
+++ b/README.md
@@ -31,13 +31,19 @@ import XCTest
 
 This is due to a confluence of problems, including test header search paths, linker issues, and more. XCTest just doesn't seem to be built to be loaded alongside your application or library code.
 
-## Solution
-
-That doesn't mean we can't try! XCTest Dynamic Overlay is a microlibrary that exposes an `XCTFail` function that can be invoked from anywhere. It dynamically loads XCTest functionality at runtime, which means your code will continue to compile just fine.
+So, the XCTest Dynamic Overlay library is a microlibrary that dynamically loads the `XCTFail` symbol
+at runtime and exposes it publicly so that it can be used from anywhere. This means you can import
+this library instead of XCTest:
 
 ```swift
 import XCTestDynamicOverlay // ✅
 ```
+
+…and your application or library will continue to compile just fine.
+
+> ⚠️ Important: The dynamically loaded `XCTFail` is only available in `DEBUG` builds in order
+to prevent App Store rejections due to runtime loading of symbols.
+
 
 ## Example
 

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/GettingStarted.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/GettingStarted.md
@@ -1,7 +1,5 @@
 # Getting Started
 
-<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
-
 ## Overview
 
 A real world example of using this is in our library, the [Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture). That library vends a `TestStore` type whose purpose is to make it easy to write tests for your application's logic. The `TestStore` uses `XCTFail` internally, and so that forces us to move the code to a dedicated test support module. However, due to how SPM works you cannot currently have that module in the same package as the main module, and so we would be forced to extract it to a separate _repo_. By loading `XCTFail` dynamically we can keep the code where it belongs.

--- a/Sources/XCTestDynamicOverlay/Documentation.docc/XCTestDynamicOverlay.md
+++ b/Sources/XCTestDynamicOverlay/Documentation.docc/XCTestDynamicOverlay.md
@@ -4,7 +4,52 @@ Define XCTest assertion helpers directly in your application and library code.
 
 ## Overview
 
-XCTest Dynamic Overlay provides APIs for invoking XCTest's `XCTFail` directly in your application and library code.
+It is very common to write test support code for libraries and applications. This often comes in the 
+form of little domain-specific functions or helpers that make it easier for users of your code to 
+formulate assertions on behavior.
+
+Currently there are only two options for writing test support code:
+
+* Put it in a test target, but then you can't access it from multiple other test targets. For 
+whatever reason test targets cannot be imported, and so the test support code will only be available 
+in that one single test target.
+* Create a dedicated test support module that ships just the test-specific code. Then you can import 
+this module into as many test targets as you want, while never letting the module interact with your 
+regular, production code.
+
+Neither of these options is ideal. In the first case you cannot share your test support, and the 
+second case will lead you to a proliferation of modules. For each feature you potentially need 3 
+modules: `MyFeature`, `MyFeatureTests` and `MyFeatureTestSupport`. SPM makes managing this quite 
+easy, but it's still a burden.
+
+It would be far better if we could ship the test support code right along side or actual library or 
+application code. After all, they are intimately related. You can even fence off the test support 
+code in `#if DEBUG ... #endif` if you are worried about leaking test code into production.
+
+However, as soon as you add `import XCTest` to a source file in your application or a library it 
+loads, the target becomes unbuildable:
+
+```swift
+import XCTest
+// 🛑 ld: warning: Could not find or use auto-linked library 'XCTestSwiftSupport'
+// 🛑 ld: warning: Could not find or use auto-linked framework 'XCTest'
+```
+
+This is due to a confluence of problems, including test header search paths, linker issues, and 
+more. XCTest just doesn't seem to be built to be loaded alongside your application or library code.
+
+So, the XCTest Dynamic Overlay library is a microlibrary that dynamically loads the `XCTFail` symbol
+at runtime and exposes it publicly so that it can be used from anywhere. This means you can import
+this library instead of XCTest:
+
+```swift
+import XCTestDynamicOverlay // ✅
+```
+
+…and your application or library will continue to compile just fine.
+
+> Important: The dynamically loaded `XCTFail` is only available in `DEBUG` builds in order
+to prevent App Store rejections due to runtime loading of symbols.
 
 ## Topics
 

--- a/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 @_transparent
 @inline(__always)
 @usableFromInline

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -162,8 +162,6 @@ import Foundation
 
 private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
   let fileAndLine: String
-//  let file: String? = "File.swift"
-//  let line: Int? = 100
   if let file, let line {
     fileAndLine = """
       :

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -125,11 +125,11 @@ import Foundation
   #else
     @_disfavoredOverload
     public func XCTFail(_ message: String = "") {
-      print(noopMessage)
+      print(noop(message: message))
     }
     @_disfavoredOverload
     public func XCTFail(_ message: String = "", file: StaticString, line: UInt) {
-      print(noopMessage)
+      print(noop(message: message, file: file, line: line))
     }
   #endif
 #else
@@ -143,7 +143,7 @@ import Foundation
   ///   results.
   @_disfavoredOverload
   public func XCTFail(_ message: String = "") {
-    print(noopMessage)
+    print(noop(message: message))
   }
 
   /// This function generates a failure immediately and unconditionally.
@@ -156,19 +156,25 @@ import Foundation
   ///   results.
   @_disfavoredOverload
   public func XCTFail(_ message: String = "", file: StaticString, line: UInt) {
-    print(noopMessage)
+    print(noop(message: message, file: file, line: line))
   }
 #endif
 
-private let noopMessage = """
+private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
+  """
+  XCTFail: \(message)
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
-┃ ⚠︎ Warning: XCTFail ignored
-┃
-┃ XCTFail was invoked in a non-DEBUG environment,
-┃ and so was ignored. Be sure to run tests with
-┃ the DEBUG=1 flag set in order to dynamically
-┃ load XCTFail.
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
-    ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
-"""
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+  ┃ ⚠︎ Warning: This XCTFail was ignored
+  ┃
+  ┃ XCTFail was invoked in a non-DEBUG environment:
+  ┃
+  ┃   \(file):\(line)
+  ┃
+  ┃  and so was ignored. Be sure to run tests with
+  ┃ the DEBUG=1 flag set in order to dynamically
+  ┃ load XCTFail.
+  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+      ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
+  """
+}

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -124,9 +124,13 @@ import Foundation
     @_exported import func XCTest.XCTFail
   #else
     @_disfavoredOverload
-    public func XCTFail(_ message: String = "") {}
+    public func XCTFail(_ message: String = "") {
+      print(noopMessage)
+    }
     @_disfavoredOverload
-    public func XCTFail(_ message: String = "", file: StaticString, line: UInt) {}
+    public func XCTFail(_ message: String = "", file: StaticString, line: UInt) {
+      print(noopMessage)
+    }
   #endif
 #else
   /// This function generates a failure immediately and unconditionally.
@@ -138,7 +142,9 @@ import Foundation
   /// - Parameter message: An optional description of the assertion, for inclusion in test
   ///   results.
   @_disfavoredOverload
-  public func XCTFail(_ message: String = "") {}
+  public func XCTFail(_ message: String = "") {
+    print(noopMessage)
+  }
 
   /// This function generates a failure immediately and unconditionally.
   ///
@@ -149,5 +155,20 @@ import Foundation
   /// - Parameter message: An optional description of the assertion, for inclusion in test
   ///   results.
   @_disfavoredOverload
-  public func XCTFail(_ message: String = "", file: StaticString, line: UInt) {}
+  public func XCTFail(_ message: String = "", file: StaticString, line: UInt) {
+    print(noopMessage)
+  }
 #endif
+
+private let noopMessage = """
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+┃ ⚠︎ Warning: XCTFail ignored
+┃
+┃ XCTFail was invoked in a non-DEBUG environment,
+┃ and so was ignored. Be sure to run tests with
+┃ the DEBUG=1 flag set in order to dynamically
+┃ load XCTFail.
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+    ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
+"""

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -162,7 +162,7 @@ import Foundation
 
 private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
   let fileAndLine: String
-  if let file, let line {
+  if let file = file, let line = line {
     fileAndLine = """
       :
       ┃

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -161,17 +161,28 @@ import Foundation
 #endif
 
 private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
-  """
+  let fileAndLine: String
+//  let file: String? = "File.swift"
+//  let line: Int? = 100
+  if let file, let line {
+    fileAndLine = """
+      :
+      ┃
+      ┃   \(file):\(line)
+      ┃
+      ┃ …
+      """
+  } else {
+    fileAndLine = "\n┃ "
+  }
+
+  return """
   XCTFail: \(message)
 
   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
   ┃ ⚠︎ Warning: This XCTFail was ignored
   ┃
-  ┃ XCTFail was invoked in a non-DEBUG environment:
-  ┃
-  ┃   \(file):\(line)
-  ┃
-  ┃  and so was ignored. Be sure to run tests with
+  ┃ XCTFail was invoked in a non-DEBUG environment\(fileAndLine)and so was ignored. Be sure to run tests with
   ┃ the DEBUG=1 flag set in order to dynamically
   ┃ load XCTFail.
   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅


### PR DESCRIPTION
Calling the dynamically loaded `XCTFail` in non-`DEBUG` builds is a no-op and so can lead people to believe their tests are passing when in reality nothing is actually happening. Let's start printing loud warnings in the console to let people know this is happening.

This is an example of what it looks like if no file/line is provided:

```
XCTFail: Unimplemented: f05 …

  Defined at:
    XCTestDynamicOverlayTests/TestHelpers.swift:71

  Invoked with:
    ("", 42, 1.2, [1, 2], XCTestDynamicOverlayTests.User(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF))

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
┃ ⚠︎ Warning: This XCTFail was ignored
┃
┃ XCTFail was invoked in a non-DEBUG environment
┃ and so was ignored. Be sure to run tests with
┃ the DEBUG=1 flag set in order to dynamically
┃ load XCTFail.
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
    ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
```

And this is an example of what it looks like when file and line is provided:

```
XCTFail: Unimplemented: f05 …

  Defined at:
    XCTestDynamicOverlayTests/TestHelpers.swift:71

  Invoked with:
    ("", 42, 1.2, [1, 2], XCTestDynamicOverlayTests.User(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF))

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
┃ ⚠︎ Warning: This XCTFail was ignored
┃
┃ XCTFail was invoked in a non-DEBUG environment:
┃
┃   File.swift:100
┃
┃ …and so was ignored. Be sure to run tests with
┃ the DEBUG=1 flag set in order to dynamically
┃ load XCTFail.
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
    ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
```