### PR TITLE
Import Foundation for String conformance to CVarArg

### DIFF
--- a/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift
@@ -19,6 +19,7 @@ func runtimeWarn(
 
 #if DEBUG && canImport(os)
   import os
+  import Foundation
 
   // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
   //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.


### PR DESCRIPTION
Xcode 14.3RC2 is warning about using the String conformance to `CVarArg` without the Foundation import. Given that Foundation would be imported implicitly, seems to make sense to do that explicitly.

```
/Users/amonshiz/Developer/xctest-dynamic-overlay/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift:15:7: warning: cannot use conformance of 'String' to 'CVarArg' here; 'Foundation' was not imported by this file; this is an error in Swift 6
      message()
      ^
/Users/amonshiz/Developer/xctest-dynamic-overlay/Sources/XCTestDynamicOverlay/Internal/RuntimeWarnings.swift:15:7: note: The missing import of module 'Foundation' will be added implicitly
      message()
      ^
```
