### PR TITLE
Add XCTExpectFailure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test-debug:
 		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
 
 test: test-debug
-	@swift test -c release | grep '⚠︎ Warning: This XCTFail was ignored' || exit 1
+	@swift test -c release | grep '⚠︎ Warning: This (XCTFail|XCTExpectFailure) was ignored' || exit 1
 
 test-linux: test-debug
 	@swift test -c release

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -74,7 +74,7 @@ import Foundation
 #endif
 
 // Rule-of-threes: this is also used in XCTFail.swift. If you need it in a third place, consider refactoring.
-private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
+private func noop(message: String?, file: StaticString? = nil, line: UInt? = nil) -> String {
   let fileAndLine: String
   if let file = file, let line = line {
     fileAndLine = """
@@ -89,7 +89,7 @@ private func noop(message: String, file: StaticString? = nil, line: UInt? = nil)
   }
 
   return """
-    XCTExpectFailure: \(message)
+    XCTExpectFailure: \(message ?? "<no message provided>")
 
     ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
     ┃ ⚠︎ Warning: This XCTExpectFailure was ignored

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+#if DEBUG
+  #if canImport(ObjectiveC)
+    /// Instructs the test to expect a failure in an upcoming assertion, with options to customize expected failure checking and handling.
+    /// - Parameters:
+    ///   - failureReason: An optional string that describes why the test expects a failure.
+    ///   - strict: A Boolean value that indicates whether the test reports an error if the expected failure doesn’t occur.
+    ///   - failingBlock: A block of test code and assertions where the test expects a failure.
+    @_transparent @_disfavoredOverload
+    public func XCTExpectFailure(
+      _ failureReason: String? = nil,
+      strict: Bool = true,
+      failingBlock: () -> Void
+    ) {
+      guard
+        let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
+          as Any as? NSObjectProtocol,
+        let options = strict
+          ? XCTExpectedFailureOptions
+            .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
+            .perform(NSSelectorFromString("init"))?.takeUnretainedValue()
+          : XCTExpectedFailureOptions
+            .perform(NSSelectorFromString("nonStrictOptions"))?.takeUnretainedValue()
+      else { return }
+
+      guard
+        let functionBlockPointer = dlsym(
+          dlopen(nil, RTLD_LAZY), "XCTExpectFailureWithOptionsInBlock")
+      else {
+        let errorString =
+          dlerror().map { charPointer in
+            String(cString: charPointer)
+          } ?? "Unknown error"
+        fatalError(
+          "Failed to get symbol for XCTExpectFailureWithOptionsInBlock with error: \(errorString).")
+      }
+
+      let XCTExpectFailureWithOptionsInBlock = unsafeBitCast(
+        functionBlockPointer,
+        to: (@convention(c) (String?, AnyObject, () -> Void) -> Void).self
+      )
+
+      XCTExpectFailureWithOptionsInBlock(failureReason, options, failingBlock)
+    }
+  #elseif canImport(XCTest)
+    // NB: It seems to be safe to import XCTest on Linux
+    @_exported import func XCTest.XCTExpectFailure
+  #else
+    @_disfavoredOverload
+    public func XCTExpectFailure(
+      _ failureReason: String? = nil,
+      strict: Bool = true,
+      failingBlock: () -> Void
+    ) {
+      print(noop(message: failureReason))
+    }
+  #endif
+#else
+
+  /// Instructs the test to expect a failure in an upcoming assertion, with options to customize expected failure checking and handling.
+  /// - Parameters:
+  ///   - failureReason: An optional string that describes why the test expects a failure.
+  ///   - strict: A Boolean value that indicates whether the test reports an error if the expected failure doesn’t occur.
+  ///   - failingBlock: A block of test code and assertions where the test expects a failure.
+  @_disfavoredOverload
+  public func XCTExpectFailure(
+    _ failureReason: String? = nil,
+    strict: Bool = true,
+    failingBlock: () -> Void
+  ) {
+    print(noop(message: failureReason))
+  }
+#endif
+
+// Rule-of-threes: this is also used in XCTFail.swift. If you need it in a third place, consider refactoring.
+private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
+  let fileAndLine: String
+  if let file = file, let line = line {
+    fileAndLine = """
+      :
+      ┃
+      ┃   \(file):\(line)
+      ┃
+      ┃ …
+      """
+  } else {
+    fileAndLine = "\n┃ "
+  }
+
+  return """
+    XCTExpectFailure: \(message)
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+    ┃ ⚠︎ Warning: This XCTExpectFailure was ignored
+    ┃
+    ┃ XCTExpectFailure was invoked in a non-DEBUG environment\(fileAndLine)and so was ignored. Be sure to run tests with
+    ┃ the DEBUG=1 flag set in order to dynamically
+    ┃ load XCTExpectFailure.
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+        ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
+    """
+}

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -160,6 +160,7 @@ import Foundation
   }
 #endif
 
+// Rule-of-threes: this is also used in XCTExpectFailure.swift. If you need it in a third place, consider refactoring.
 private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
   let fileAndLine: String
   if let file = file, let line = line {

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -5,6 +5,10 @@ func MyXCTFail(_ message: String) {
   XCTFail(message)
 }
 
+func MyXCTExpectFailure(strict: Bool, message: String, failingBlock: () -> Void) {
+  XCTExpectFailure(message, strict: strict, failingBlock: failingBlock)
+}
+
 struct Client {
   var p00: () -> Int
   var p01: () throws -> Int

--- a/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
@@ -10,7 +10,7 @@
           Unimplemented: f00 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:66
+              XCTestDynamicOverlayTests/TestHelpers.swift:70
           """
       }
 
@@ -21,7 +21,7 @@
           Unimplemented: f01 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:67
+              XCTestDynamicOverlayTests/TestHelpers.swift:71
 
             Invoked with:
               ""
@@ -35,7 +35,7 @@
           Unimplemented: f02 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:68
+              XCTestDynamicOverlayTests/TestHelpers.swift:72
 
             Invoked with:
               ("", 42)
@@ -49,7 +49,7 @@
           Unimplemented: f03 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:69
+              XCTestDynamicOverlayTests/TestHelpers.swift:73
 
             Invoked with:
               ("", 42, 1.2)
@@ -63,7 +63,7 @@
           Unimplemented: f04 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:70
+              XCTestDynamicOverlayTests/TestHelpers.swift:74
 
             Invoked with:
               ("", 42, 1.2, [1, 2])
@@ -79,7 +79,7 @@
           Unimplemented: f05 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:71
+              XCTestDynamicOverlayTests/TestHelpers.swift:75
 
             Invoked with:
               ("", 42, 1.2, [1, 2], XCTestDynamicOverlayTests.User(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF))

--- a/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+final class XCTExpectFailureTests: XCTestCase {
+  func testXCTDynamicOverlayShouldFail() async throws {
+    MyXCTExpectFailure(strict: false, message: "This is expected to pass.") {
+      XCTAssertEqual(42, 42)
+    }
+
+    MyXCTExpectFailure(strict: true, message: "This is expected to pass.") {
+      XCTAssertEqual(42, 1729)
+    }
+
+    if ProcessInfo.processInfo.environment["TEST_FAILURE"] != nil {
+      MyXCTExpectFailure(strict: true, message: "This is expected to fail!") {
+        XCTAssertEqual(42, 42)
+      }
+    }
+  }
+}

--- a/Tests/XCTestDynamicOverlayTests/XCTFailTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTFailTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-final class XCTestDynamicOverlayTests: XCTestCase {
+final class XCTFailTests: XCTestCase {
   func testXCTFailShouldFail() async throws {
     if ProcessInfo.processInfo.environment["TEST_FAILURE"] != nil {
       MyXCTFail("This is expected to fail!")


### PR DESCRIPTION
I'm not sure how correct this is, since I'm not experienced with the dlsym/dlopen stuff. It's copied from the TCA code per discussion in https://github.com/pointfreeco/xctest-dynamic-overlay/discussions/58.

I'm also not sure if the tests are correct, but I figured they'd be a good starting point.