### PR TITLE
Add unimplemented for 6 and 7 parameters

### DIFF
--- a/Sources/XCTestDynamicOverlay/Unimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/Unimplemented.swift
@@ -187,6 +187,60 @@ public func unimplemented<A, B, C, D, E, Result>(
   }
 }
 
+public func unimplemented<A, B, C, D, E, F, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  placeholder: @autoclosure @escaping @Sendable () -> Result,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F) -> Result {
+  return {
+    _fail(description(), ($0, $1, $2, $3, $4, $5), fileID: fileID, line: line)
+    return placeholder()
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F) -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5), fileID: fileID, line: line)
+    guard let placeholder: Result = _generatePlaceholder()
+    else { _unimplementedFatalError(description, file: file, line: line) }
+    return placeholder
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, G, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  placeholder: @autoclosure @escaping @Sendable () -> Result,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F, G) -> Result {
+  return {
+    _fail(description(), ($0, $1, $2, $3, $4, $5, $6), fileID: fileID, line: line)
+    return placeholder()
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, G, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F, G) -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5, $6), fileID: fileID, line: line)
+    guard let placeholder: Result = _generatePlaceholder()
+    else { _unimplementedFatalError(description, file: file, line: line) }
+    return placeholder
+  }
+}
+
 // MARK: (Parameters) throws -> Result
 
 public func unimplemented<Result>(
@@ -257,6 +311,30 @@ public func unimplemented<A, B, C, D, E, Result>(
   return {
     let description = description()
     _fail(description, ($0, $1, $2, $3, $4), fileID: fileID, line: line)
+    throw UnimplementedFailure(description: description)
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F) throws -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5), fileID: fileID, line: line)
+    throw UnimplementedFailure(description: description)
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, G, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F, G) throws -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5, $6), fileID: fileID, line: line)
     throw UnimplementedFailure(description: description)
   }
 }
@@ -434,6 +512,60 @@ public func unimplemented<A, B, C, D, E, Result>(
   }
 }
 
+public func unimplemented<A, B, C, D, E, F, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  placeholder: @autoclosure @escaping @Sendable () -> Result,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F) async -> Result {
+  return {
+    _fail(description(), ($0, $1, $2, $3, $4, $5), fileID: fileID, line: line)
+    return placeholder()
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F) async -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5), fileID: fileID, line: line)
+    guard let placeholder: Result = _generatePlaceholder()
+    else { _unimplementedFatalError(description, file: file, line: line) }
+    return placeholder
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, G, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  placeholder: @autoclosure @escaping @Sendable () -> Result,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F, G) async -> Result {
+  return {
+    _fail(description(), ($0, $1, $2, $3, $4, $5, $6), fileID: fileID, line: line)
+    return placeholder()
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, G, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F, G) async -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5, $6), fileID: fileID, line: line)
+    guard let placeholder: Result = _generatePlaceholder()
+    else { _unimplementedFatalError(description, file: file, line: line) }
+    return placeholder
+  }
+}
+
 // MARK: (Parameters) async throws -> Result
 
 public func unimplemented<Result>(
@@ -509,6 +641,30 @@ public func unimplemented<A, B, C, D, E, Result>(
   return {
     let description = description()
     _fail(description, ($0, $1, $2, $3, $4), fileID: fileID, line: line)
+    throw UnimplementedFailure(description: description)
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F) async throws -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5), fileID: fileID, line: line)
+    throw UnimplementedFailure(description: description)
+  }
+}
+
+public func unimplemented<A, B, C, D, E, F, G, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  fileID: StaticString = #fileID,
+  line: UInt = #line
+) -> @Sendable (A, B, C, D, E, F, G) async throws -> Result {
+  return {
+    let description = description()
+    _fail(description, ($0, $1, $2, $3, $4, $5, $6), fileID: fileID, line: line)
     throw UnimplementedFailure(description: description)
   }
 }

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -30,6 +30,14 @@ struct Client {
   var p21: (Int, Int, Int, Int, Int) throws -> Int
   var p22: (Int, Int, Int, Int, Int) async -> Int
   var p23: (Int, Int, Int, Int, Int) async throws -> Int
+  var p24: (Int, Int, Int, Int, Int, Int) -> Int
+  var p25: (Int, Int, Int, Int, Int, Int) throws -> Int
+  var p26: (Int, Int, Int, Int, Int, Int) async -> Int
+  var p27: (Int, Int, Int, Int, Int, Int) async throws -> Int
+  var p28: (Int, Int, Int, Int, Int, Int, Int) -> Int
+  var p29: (Int, Int, Int, Int, Int, Int, Int) throws -> Int
+  var p30: (Int, Int, Int, Int, Int, Int, Int) async -> Int
+  var p31: (Int, Int, Int, Int, Int, Int, Int) async throws -> Int
 
   static var testValue: Self {
     Self(
@@ -56,12 +64,22 @@ struct Client {
       p20: unimplemented("\(Self.self).p20"),
       p21: unimplemented("\(Self.self).p21"),
       p22: unimplemented("\(Self.self).p22"),
-      p23: unimplemented("\(Self.self).p23")
+      p23: unimplemented("\(Self.self).p23"),
+      p24: unimplemented("\(Self.self).p24"),
+      p25: unimplemented("\(Self.self).p25"),
+      p26: unimplemented("\(Self.self).p26"),
+      p27: unimplemented("\(Self.self).p27"),
+      p28: unimplemented("\(Self.self).p28"),
+      p29: unimplemented("\(Self.self).p29"),
+      p30: unimplemented("\(Self.self).p30"),
+      p31: unimplemented("\(Self.self).p31")
     )
   }
 }
 
 struct User { let id: UUID }
+struct Domain { let id: UUID }
+struct Session { let id: UUID }
 
 let f00: () -> Int = unimplemented("f00", placeholder: 42)
 let f01: (String) -> Int = unimplemented("f01", placeholder: 42)
@@ -69,6 +87,8 @@ let f02: (String, Int) -> Int = unimplemented("f02", placeholder: 42)
 let f03: (String, Int, Double) -> Int = unimplemented("f03", placeholder: 42)
 let f04: (String, Int, Double, [Int]) -> Int = unimplemented("f04", placeholder: 42)
 let f05: (String, Int, Double, [Int], User) -> Int = unimplemented("f05", placeholder: 42)
+let f06: (String, Int, Double, [Int], User, Domain) -> Int = unimplemented("f06", placeholder: 42)
+let f07: (String, Int, Double, [Int], User, Domain, Session) -> Int = unimplemented("f07", placeholder: 42)
 
 private struct Autoclosing {
   init(

--- a/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
@@ -10,7 +10,7 @@
           Unimplemented: f00 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:66
+              XCTestDynamicOverlayTests/TestHelpers.swift:84
           """
       }
 
@@ -21,7 +21,7 @@
           Unimplemented: f01 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:67
+              XCTestDynamicOverlayTests/TestHelpers.swift:85
 
             Invoked with:
               ""
@@ -35,7 +35,7 @@
           Unimplemented: f02 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:68
+              XCTestDynamicOverlayTests/TestHelpers.swift:86
 
             Invoked with:
               ("", 42)
@@ -49,7 +49,7 @@
           Unimplemented: f03 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:69
+              XCTestDynamicOverlayTests/TestHelpers.swift:87
 
             Invoked with:
               ("", 42, 1.2)
@@ -63,7 +63,7 @@
           Unimplemented: f04 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:70
+              XCTestDynamicOverlayTests/TestHelpers.swift:88
 
             Invoked with:
               ("", 42, 1.2, [1, 2])
@@ -79,11 +79,43 @@
           Unimplemented: f05 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:71
+              XCTestDynamicOverlayTests/TestHelpers.swift:89
 
             Invoked with:
               ("", 42, 1.2, [1, 2], XCTestDynamicOverlayTests.User(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF))
           """
+      }
+
+      _ = XCTExpectFailure {
+        f06(
+          "", 42, 1.2, [1, 2], User(id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!), Domain(id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
+        )
+      } issueMatcher: {
+        $0.compactDescription == """
+        Unimplemented: f06 …
+
+          Defined at:
+            XCTestDynamicOverlayTests/TestHelpers.swift:90
+
+          Invoked with:
+            ("", 42, 1.2, [1, 2], XCTestDynamicOverlayTests.User(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF), XCTestDynamicOverlayTests.Domain(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF))
+        """
+      }
+
+      _ = XCTExpectFailure {
+        f07(
+          "", 42, 1.2, [1, 2], User(id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!), Domain(id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!), Session(id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!)
+        )
+      } issueMatcher: {
+        $0.compactDescription == """
+        Unimplemented: f07 …
+
+          Defined at:
+            XCTestDynamicOverlayTests/TestHelpers.swift:91
+
+          Invoked with:
+            ("", 42, 1.2, [1, 2], XCTestDynamicOverlayTests.User(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF), XCTestDynamicOverlayTests.Domain(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF), XCTestDynamicOverlayTests.Session(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF))
+        """
       }
     }
   }


### PR DESCRIPTION
As I was writing a protocol witness for the Auth0 package I found some of their functions take 6 or 7 parameters. 