### PR TITLE
Add `XCTFailContext` task local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: make test-linux
 
   wasm:
-     name: SwiftWASM
+     name: Wasm
      runs-on: ubuntu-latest
      strategy:
        matrix:

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -1,6 +1,18 @@
 import Foundation
 
 #if DEBUG
+  public struct XCTFailContext {
+    @TaskLocal public static var current: Self?
+
+    public var file: StaticString
+    public var line: UInt
+
+    public init(file: StaticString, line: UInt) {
+      self.file = file
+      self.line = line
+    }
+  }
+
   #if canImport(ObjectiveC)
     /// This function generates a failure immediately and unconditionally.
     ///
@@ -12,6 +24,10 @@ import Foundation
     ///   results.
     @_disfavoredOverload
     public func XCTFail(_ message: String = "") {
+      if let context = XCTFailContext.current {
+        XCTFail(message, file: context.file, line: context.line)
+        return
+      }
       var message = message
       attachHostApplicationWarningIfNeeded(&message)
       guard

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-#if DEBUG
-  public struct XCTFailContext {
-    @TaskLocal public static var current: Self?
+public struct XCTFailContext {
+  @TaskLocal public static var current: Self?
 
-    public var file: StaticString
-    public var line: UInt
+  public var file: StaticString
+  public var line: UInt
 
-    public init(file: StaticString, line: UInt) {
-      self.file = file
-      self.line = line
-    }
+  public init(file: StaticString, line: UInt) {
+    self.file = file
+    self.line = line
   }
+}
 
+#if DEBUG
   #if canImport(ObjectiveC)
     /// This function generates a failure immediately and unconditionally.
     ///

--- a/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
@@ -1,0 +1,17 @@
+#if !os(Linux)
+  import XCTest
+  import XCTestDynamicOverlay
+
+  public final class XCTContextTests: XCTestCase {
+    func testContext() {
+      XCTExpectFailure {
+        $0.compactDescription == "Failed"
+          && $0.sourceCodeContext.location
+            == XCTSourceCodeLocation(filePath: "unknown", lineNumber: 1)
+      }
+      XCTFailContext.$current.withValue(XCTFailContext(file: "unknown", line: 1)) {
+        XCTestDynamicOverlay.XCTFail("Failed")
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
This allows us to provide APIs that thread the `file`/`line` through concurrent contexts that otherwise lose the stack.