### PR TITLE
Swift 5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
      strategy:
        matrix:
          include:
-           - { toolchain: wasm-5.6.0-RELEASE }
+           - { toolchain: wasm-5.5.0-RELEASE }
 
      steps:
        - uses: actions/checkout@v3
        - run: echo "${{ matrix.toolchain }}" > .swift-version
-       - uses: swiftwasm/swiftwasm-action@v5.6
+       - uses: swiftwasm/swiftwasm-action@v5.5
          with:
            shell-action: swift build

--- a/Sources/XCTestDynamicOverlay/Internal/GeneratePlaceholder.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/GeneratePlaceholder.swift
@@ -11,7 +11,7 @@ extension RangeReplaceableCollection { fileprivate static var placeholder: Self 
 private protocol _OptionalProtocol { static var none: Self { get } }
 extension Optional: _OptionalProtocol {}
 private func _optionalPlaceholder<Result>() throws -> Result {
-  if let result = (Result.self as? any _OptionalProtocol.Type) {
+  if let result = (Result.self as? _OptionalProtocol.Type) {
     return result.none as! Result
   }
   throw PlaceholderGenerationFailure()


### PR DESCRIPTION
While we should bump our minimum Swift tools version soon, this will recover compilation in 5.5.