### PR TITLE
Add Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,27 @@ jobs:
        - uses: swiftwasm/swiftwasm-action@v5.5
          with:
            shell-action: swift build
+
+  windows:
+    name: Windows
+    strategy:
+      matrix:
+        os: [windows-latest]
+        config: ['debug', 'release']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-5.8.1-release
+          tag: 5.8.1-RELEASE
+      - uses: actions/checkout@v3
+      - name: Build
+        run: swift build -c ${{ matrix.config }}
+      - name: Run tests (debug only)
+        # There is an issue that exists in the 5.8.1 toolchain
+        # which fails on release configuration testing, but
+        # this issue is fixed 5.9 so we can remove the if once
+        # that is generally available.
+        if: ${{ matrix.config == 'debug' }}
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   ]
 )
 
-#if swift(>=5.6)
+#if swift(>=5.6) && !os(Windows)
   // Add the documentation compiler plugin if possible
   package.dependencies.append(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")

--- a/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
@@ -1,4 +1,5 @@
-#if !os(Linux)
+// TODO: https://github.com/apple/swift-corelibs-xctest/issues/438
+#if !os(Linux) && !os(Windows)
   import Foundation
   import XCTest
   import XCTestDynamicOverlay

--- a/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
@@ -1,4 +1,5 @@
-#if !os(Linux)
+// TODO: https://github.com/apple/swift-corelibs-xctest/issues/438
+#if !os(Linux) && !os(Windows)
   import XCTest
 
   final class UnimplementedTests: XCTestCase {

--- a/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
@@ -1,4 +1,5 @@
-#if !os(Linux)
+// TODO: https://github.com/apple/swift-corelibs-xctest/issues/438
+#if !os(Linux) && !os(Windows)
   import XCTest
   import XCTestDynamicOverlay
 


### PR DESCRIPTION
Skip tests where XCTExpectedFailure is used as this behavior is currently unimplemented on Windows and Linux (https://github.com/apple/swift-corelibs-xctest/issues/438)