### PR TITLE
XCTestDynamicOverlay: prefer delay loading `XCTFail`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
      strategy:
        matrix:
          include:
-           - { toolchain: wasm-5.5.0-RELEASE }
+           - { toolchain: wasm-5.7.1-RELEASE }
 
      steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@v4
        - run: echo "${{ matrix.toolchain }}" > .swift-version
-       - uses: swiftwasm/swiftwasm-action@v5.5
+       - uses: swiftwasm/swiftwasm-action@v5.7
          with:
            shell-action: swift build
 

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -167,13 +167,11 @@ public struct XCTFailContext {
       import WinSDK
 
       private func ResolveXCTFail() -> XCTFailType? {
-        let hXCTest = Array("XCTest.dll".utf16).withUnsafeBufferPointer {
-          LoadLibraryW($0.baseAddress)
-        }
+        let hXCTest = LoadLibraryA("XCTest.dll")
         guard let hXCTest else { return nil }
 
         if let pXCTFail = GetProcAddress(hXCTest, "$s6XCTest7XCTFail_4file4lineySS_s12StaticStringVSutF") {
-          return unsafeCastToXCTFailType(pXCTFail)
+          return unsafeCastToXCTFailType(unsafeBitCast(pXCTFail, to: UnsafeRawPointer.self))
         }
 
         return nil


### PR DESCRIPTION
Similar to the ObjC XCTest, prefer to delay load the XCTest runtime. This is likely to fail on release distributions as XCTest is a developer component. However, if it is available in the library search path on (non-Darwin) Unix or in `Path` on Windows, it will be used.

Windows does not (yet) ship a static XCTest library. On Linux, it is unclear whether the linkage is dynamic or static, so we perform a little trick. We pass `RTLD_NOLOAD` to `dlopen` which will get a handle to `libXCTest.so` if it is currently loaded in the address space but not load the library if not already there. In such a case, it will return `NULL`. In such a case, we resort to looking within the main binary (assuming that XCTest may have been statically linked).

For both platforms, if we do not find the symbol from XCTest, we will proceed to simply use the fallback path.

Note that both `GetProcAddress` and `dlsym` do not know how to cast the resulting pointer to indicate the calling convention. As a result, we rely on the use of `unsafeBitCast` to restore the calling convention to `swiftcall`. To completely avoid the undefined behaviour here, we would need to resort to C to perform the cast as these methods return type erased pointers (i.e. `void *`).