### PR TITLE
Add `XCTExpectFailure`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test-debug:
 		|| (echo "$(FAIL) expected $(XCT_FAIL) to be called with $(EXPECTED)" >&2 && exit 1)
 
 test: test-debug
-	@swift test -c release | grep '⚠︎ Warning: This XCTFail was ignored' || exit 1
+	@swift test -c release | grep '⚠︎ Warning: This (XCTFail|XCTExpectFailure) was ignored' || exit 1
 
 test-linux: test-debug
 	@swift test -c release

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ test-debug:
 test: test-debug
 	@swift test -c release
 
-test-linux: test-debug
-	@swift test -c release
+test-linux: test
 
 test-linux-docker:
 	@docker run \

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -1,103 +1,180 @@
 import Foundation
 
-#if DEBUG
-  #if canImport(ObjectiveC)
-    /// Instructs the test to expect a failure in an upcoming assertion, with options to customize expected failure checking and handling.
-    /// - Parameters:
-    ///   - failureReason: An optional string that describes why the test expects a failure.
-    ///   - strict: A Boolean value that indicates whether the test reports an error if the expected failure doesn’t occur.
-    ///   - failingBlock: A block of test code and assertions where the test expects a failure.
-    @_transparent @_disfavoredOverload
-    public func XCTExpectFailure(
-      _ failureReason: String? = nil,
-      strict: Bool = true,
-      failingBlock: () -> Void
-    ) {
-      guard
-        let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
-          as Any as? NSObjectProtocol,
-        let options = strict
-          ? XCTExpectedFailureOptions
-            .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
-            .perform(NSSelectorFromString("init"))?.takeUnretainedValue()
-          : XCTExpectedFailureOptions
-            .perform(NSSelectorFromString("nonStrictOptions"))?.takeUnretainedValue()
-      else { return }
-
-      guard
-        let functionBlockPointer = dlsym(
-          dlopen(nil, RTLD_LAZY), "XCTExpectFailureWithOptionsInBlock")
-      else {
-        let errorString =
-          dlerror().map { charPointer in
-            String(cString: charPointer)
-          } ?? "Unknown error"
-        fatalError(
-          "Failed to get symbol for XCTExpectFailureWithOptionsInBlock with error: \(errorString).")
-      }
-
-      let XCTExpectFailureWithOptionsInBlock = unsafeBitCast(
-        functionBlockPointer,
-        to: (@convention(c) (String?, AnyObject, () -> Void) -> Void).self
-      )
-
-      XCTExpectFailureWithOptionsInBlock(failureReason, options, failingBlock)
-    }
-  #elseif canImport(XCTest)
-    // NB: It seems to be safe to import XCTest on Linux
-    @_exported import func XCTest.XCTExpectFailure
-  #else
-    @_disfavoredOverload
-    public func XCTExpectFailure(
-      _ failureReason: String? = nil,
-      strict: Bool = true,
-      failingBlock: () -> Void
-    ) {
-      print(noop(message: failureReason))
-    }
-  #endif
-#else
-
-  /// Instructs the test to expect a failure in an upcoming assertion, with options to customize expected failure checking and handling.
+#if DEBUG && canImport(ObjectiveC)
+  /// Instructs the test to expect a failure in an upcoming assertion, with options to customize
+  /// expected failure checking and handling.
   /// - Parameters:
   ///   - failureReason: An optional string that describes why the test expects a failure.
-  ///   - strict: A Boolean value that indicates whether the test reports an error if the expected failure doesn’t occur.
+  ///   - enabled: A Boolean value that indicates whether the test checks for the expected failure.
+  ///   - strict: A Boolean value that indicates whether the test reports an error if the expected
+  ///     failure doesn’t occur.
   ///   - failingBlock: A block of test code and assertions where the test expects a failure.
+  @_disfavoredOverload
+  public func XCTExpectFailure<R>(
+    _ failureReason: String? = nil,
+    enabled: Bool? = nil,
+    strict: Bool? = nil,
+    failingBlock: () throws -> R,
+    issueMatcher: ((_XCTIssue) -> Bool)? = nil
+  ) rethrows -> R {
+    guard enabled ?? true
+    else { return try failingBlock() }
+    guard
+      let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
+        as Any as? NSObjectProtocol,
+      let options = strict ?? true
+        ? XCTExpectedFailureOptions
+          .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
+          .perform(NSSelectorFromString("init"))?.takeUnretainedValue()
+        : XCTExpectedFailureOptions
+          .perform(NSSelectorFromString("nonStrictOptions"))?.takeUnretainedValue(),
+      let functionBlockPointer = dlsym(dlopen(nil, RTLD_LAZY), "XCTExpectFailureWithOptionsInBlock")
+    else {
+      let errorString = dlerror().map { charPointer in String(cString: charPointer) }
+        ?? "Unknown error"
+      assertionFailure(
+        "Failed to get symbol for XCTExpectFailureWithOptionsInBlock with error: \(errorString)."
+      )
+      return try failingBlock()
+    }
+
+    if let issueMatcher = issueMatcher {
+      let issueMatcher: @convention(block) (AnyObject) -> Bool = { issue in
+        issueMatcher(_XCTIssue(issue))
+      }
+      options.setValue(issueMatcher, forKey: "issueMatcher")
+    }
+
+    let XCTExpectFailureWithOptionsInBlock = unsafeBitCast(
+      functionBlockPointer,
+      to: (@convention(c) (String?, AnyObject, () -> Void) -> Void).self
+    )
+
+    var result: Result<R, Error>!
+    XCTExpectFailureWithOptionsInBlock(failureReason, options) {
+      result = Result { try failingBlock() }
+    }
+    return try result._rethrowGet()
+  }
+
+  /// Instructs the test to expect a failure in an upcoming assertion, with options to customize
+  /// expected failure checking and handling.
+  /// - Parameters:
+  ///   - failureReason: An optional string that describes why the test expects a failure.
+  ///   - enabled: A Boolean value that indicates whether the test checks for the expected failure.
+  ///   - strict: A Boolean value that indicates whether the test reports an error if the expected
+  ///     failure doesn’t occur.
   @_disfavoredOverload
   public func XCTExpectFailure(
     _ failureReason: String? = nil,
-    strict: Bool = true,
-    failingBlock: () -> Void
+    enabled: Bool? = nil,
+    strict: Bool? = nil,
+    issueMatcher: ((_XCTIssue) -> Bool)? = nil
   ) {
-    print(noop(message: failureReason))
+    guard enabled ?? true
+    else { return }
+    guard
+      let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
+        as Any as? NSObjectProtocol,
+      let options = strict ?? true
+        ? XCTExpectedFailureOptions
+          .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
+          .perform(NSSelectorFromString("init"))?.takeUnretainedValue()
+        : XCTExpectedFailureOptions
+          .perform(NSSelectorFromString("nonStrictOptions"))?.takeUnretainedValue(),
+      let functionBlockPointer = dlsym(dlopen(nil, RTLD_LAZY), "XCTExpectFailureWithOptions")
+    else {
+      let errorString = dlerror().map { charPointer in String(cString: charPointer) }
+        ?? "Unknown error"
+      assertionFailure(
+        "Failed to get symbol for XCTExpectFailureWithOptionsInBlock with error: \(errorString)."
+      )
+      return
+    }
+
+    if let issueMatcher = issueMatcher {
+      let issueMatcher: @convention(block) (AnyObject) -> Bool = { issue in
+        issueMatcher(_XCTIssue(issue))
+      }
+      options.setValue(issueMatcher, forKey: "issueMatcher")
+    }
+
+    let XCTExpectFailureWithOptions = unsafeBitCast(
+      functionBlockPointer,
+      to: (@convention(c) (String?, AnyObject) -> Void).self
+    )
+
+    XCTExpectFailureWithOptions(failureReason, options)
   }
+
+
+  public struct _XCTIssue: /*CustomStringConvertible, */Equatable, Hashable {
+    public var type: IssueType
+    public var compactDescription: String
+    public var detailedDescription: String?
+
+    // var sourceCodeContext: XCTSourceCodeContext
+    // var associatedError: Error?
+    // var attachments: [XCTAttachment]
+    // mutating func add(XCTAttachment)
+    //
+    // public var description: String {
+    //   """
+    //   \(self.type.description) \
+    //   at \
+    //   \(self.sourceCodeContext.location.fileURL.lastPathComponent):\
+    //   \(self.sourceCodeContext.location.lineNumber): \
+    //   \(self.compactDescription)
+    //   """
+    // }
+
+    init(_ issue: AnyObject) {
+      self.type = IssueType(rawValue: issue.value(forKey: "type") as! Int)!
+      self.compactDescription = issue.value(forKey: "compactDescription") as! String
+      self.detailedDescription = issue.value(forKey: "detailedDescription") as? String
+    }
+
+    public enum IssueType: Int, Sendable {
+      case assertionFailure = 0
+      case performanceRegression = 3
+      case system = 4
+      case thrownError = 1
+      case uncaughtException = 2
+      case unmatchedExpectedFailure = 5
+
+      var description: String {
+        switch self {
+        case .assertionFailure:
+          return "Assertion Failure"
+        case .performanceRegression:
+          return "Performance Regression"
+        case .system:
+          return "System Error"
+        case .thrownError:
+          return "Thrown Error"
+        case .uncaughtException:
+          return "Uncaught Exception"
+        case .unmatchedExpectedFailure:
+          return "Unmatched ExpectedFailure"
+        }
+      }
+    }
+  }
+
+  @rethrows
+  private protocol _ErrorMechanism {
+    associatedtype Output
+    func get() throws -> Output
+  }
+  extension _ErrorMechanism {
+    func _rethrowError() rethrows -> Never {
+      _ = try _rethrowGet()
+      fatalError()
+    }
+    @usableFromInline
+    func _rethrowGet() rethrows -> Output {
+      return try get()
+    }
+  }
+  extension Result: _ErrorMechanism {}
 #endif
-
-// Rule-of-threes: this is also used in XCTFail.swift. If you need it in a third place, consider refactoring.
-private func noop(message: String?, file: StaticString? = nil, line: UInt? = nil) -> String {
-  let fileAndLine: String
-  if let file = file, let line = line {
-    fileAndLine = """
-      :
-      ┃
-      ┃   \(file):\(line)
-      ┃
-      ┃ …
-      """
-  } else {
-    fileAndLine = "\n┃ "
-  }
-
-  return """
-    XCTExpectFailure: \(message ?? "<no message provided>")
-
-    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
-    ┃ ⚠︎ Warning: This XCTExpectFailure was ignored
-    ┃
-    ┃ XCTExpectFailure was invoked in a non-DEBUG environment\(fileAndLine)and so was ignored. Be sure to run tests with
-    ┃ the DEBUG=1 flag set in order to dynamically
-    ┃ load XCTExpectFailure.
-    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
-        ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
-    """
-}

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -113,6 +113,9 @@ import Foundation
     public var compactDescription: String
     public var detailedDescription: String?
 
+    // NB: This surface are has been left unimplemented for now. We can consider adopting more of it
+    //     in the future:
+    //
     // var sourceCodeContext: XCTSourceCodeContext
     // var associatedError: Error?
     // var attachments: [XCTAttachment]

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -74,7 +74,7 @@ import Foundation
 #endif
 
 // Rule-of-threes: this is also used in XCTFail.swift. If you need it in a third place, consider refactoring.
-private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
+private func noop(message: String?, file: StaticString? = nil, line: UInt? = nil) -> String {
   let fileAndLine: String
   if let file = file, let line = line {
     fileAndLine = """
@@ -89,7 +89,7 @@ private func noop(message: String, file: StaticString? = nil, line: UInt? = nil)
   }
 
   return """
-    XCTExpectFailure: \(message)
+    XCTExpectFailure: \(message ?? "<no message provided>")
 
     ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
     ┃ ⚠︎ Warning: This XCTExpectFailure was ignored

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -3,6 +3,7 @@ import Foundation
 #if DEBUG && canImport(ObjectiveC)
   /// Instructs the test to expect a failure in an upcoming assertion, with options to customize
   /// expected failure checking and handling.
+  ///
   /// - Parameters:
   ///   - failureReason: An optional string that describes why the test expects a failure.
   ///   - enabled: A Boolean value that indicates whether the test checks for the expected failure.
@@ -59,6 +60,7 @@ import Foundation
 
   /// Instructs the test to expect a failure in an upcoming assertion, with options to customize
   /// expected failure checking and handling.
+  ///
   /// - Parameters:
   ///   - failureReason: An optional string that describes why the test expects a failure.
   ///   - enabled: A Boolean value that indicates whether the test checks for the expected failure.
@@ -106,7 +108,6 @@ import Foundation
 
     XCTExpectFailureWithOptions(failureReason, options)
   }
-
 
   public struct _XCTIssue: /*CustomStringConvertible, */Equatable, Hashable {
     public var type: IssueType

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+#if DEBUG
+  #if canImport(ObjectiveC)
+    /// Instructs the test to expect a failure in an upcoming assertion, with options to customize expected failure checking and handling.
+    /// - Parameters:
+    ///   - failureReason: An optional string that describes why the test expects a failure.
+    ///   - strict: A Boolean value that indicates whether the test reports an error if the expected failure doesn’t occur.
+    ///   - failingBlock: A block of test code and assertions where the test expects a failure.
+    @_transparent @_disfavoredOverload
+    public func XCTExpectFailure(
+      _ failureReason: String? = nil,
+      strict: Bool = true,
+      failingBlock: () -> Void
+    ) {
+      guard
+        let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
+          as Any as? NSObjectProtocol,
+        let options = strict
+          ? XCTExpectedFailureOptions
+            .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
+            .perform(NSSelectorFromString("init"))?.takeUnretainedValue()
+          : XCTExpectedFailureOptions
+            .perform(NSSelectorFromString("nonStrictOptions"))?.takeUnretainedValue()
+      else { return }
+
+      guard
+        let functionBlockPointer = dlsym(
+          dlopen(nil, RTLD_LAZY), "XCTExpectFailureWithOptionsInBlock")
+      else {
+        let errorString =
+          dlerror().map { charPointer in
+            String(cString: charPointer)
+          } ?? "Unknown error"
+        fatalError(
+          "Failed to get symbol for XCTExpectFailureWithOptionsInBlock with error: \(errorString).")
+      }
+
+      let XCTExpectFailureWithOptionsInBlock = unsafeBitCast(
+        functionBlockPointer,
+        to: (@convention(c) (String?, AnyObject, () -> Void) -> Void).self
+      )
+
+      XCTExpectFailureWithOptionsInBlock(failureReason, options, failingBlock)
+    }
+  #elseif canImport(XCTest)
+    // NB: It seems to be safe to import XCTest on Linux
+    @_exported import func XCTest.XCTExpectFailure
+  #else
+    @_disfavoredOverload
+    public func XCTExpectFailure(
+      _ failureReason: String? = nil,
+      strict: Bool = true,
+      failingBlock: () -> Void
+    ) {
+      print(noop(message: failureReason))
+    }
+  #endif
+#else
+
+  /// Instructs the test to expect a failure in an upcoming assertion, with options to customize expected failure checking and handling.
+  /// - Parameters:
+  ///   - failureReason: An optional string that describes why the test expects a failure.
+  ///   - strict: A Boolean value that indicates whether the test reports an error if the expected failure doesn’t occur.
+  ///   - failingBlock: A block of test code and assertions where the test expects a failure.
+  @_disfavoredOverload
+  public func XCTExpectFailure(
+    _ failureReason: String? = nil,
+    strict: Bool = true,
+    failingBlock: () -> Void
+  ) {
+    print(noop(message: failureReason))
+  }
+#endif
+
+// Rule-of-threes: this is also used in XCTFail.swift. If you need it in a third place, consider refactoring.
+private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
+  let fileAndLine: String
+  if let file = file, let line = line {
+    fileAndLine = """
+      :
+      ┃
+      ┃   \(file):\(line)
+      ┃
+      ┃ …
+      """
+  } else {
+    fileAndLine = "\n┃ "
+  }
+
+  return """
+    XCTExpectFailure: \(message)
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+    ┃ ⚠︎ Warning: This XCTExpectFailure was ignored
+    ┃
+    ┃ XCTExpectFailure was invoked in a non-DEBUG environment\(fileAndLine)and so was ignored. Be sure to run tests with
+    ┃ the DEBUG=1 flag set in order to dynamically
+    ┃ load XCTExpectFailure.
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┉┅
+        ▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄▀▄
+    """
+}

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -160,7 +160,6 @@ import Foundation
   }
 #endif
 
-// Rule-of-threes: this is also used in XCTExpectFailure.swift. If you need it in a third place, consider refactoring.
 private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
   let fileAndLine: String
   if let file = file, let line = line {

--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -160,6 +160,7 @@ import Foundation
   }
 #endif
 
+// Rule-of-threes: this is also used in XCTExpectFailure.swift. If you need it in a third place, consider refactoring.
 private func noop(message: String, file: StaticString? = nil, line: UInt? = nil) -> String {
   let fileAndLine: String
   if let file = file, let line = line {

--- a/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
@@ -1,5 +1,4 @@
-// TODO: https://github.com/apple/swift-corelibs-xctest/issues/438
-#if !os(Linux) && !os(Windows)
+#if DEBUG && !os(Linux) && !os(Windows)
   import Foundation
   import XCTest
   import XCTestDynamicOverlay

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -5,35 +5,37 @@ func MyXCTFail(_ message: String) {
   XCTFail(message)
 }
 
-func MyXCTExpectFailure(
-  _ failureReason: String,
-  enabled: Bool = true,
-  strict: Bool = true,
-  failingBlock: () -> Void,
-  issueMatcher: ((_XCTIssue) -> Bool)? = nil
-) {
-  XCTExpectFailure(
-    failureReason,
-    enabled: enabled,
-    strict: strict,
-    failingBlock: failingBlock,
-    issueMatcher: issueMatcher
-  )
-}
+#if canImport(ObjectiveC)
+  func MyXCTExpectFailure(
+    _ failureReason: String,
+    enabled: Bool = true,
+    strict: Bool = true,
+    failingBlock: () -> Void,
+    issueMatcher: ((_XCTIssue) -> Bool)? = nil
+  ) {
+    XCTExpectFailure(
+      failureReason,
+      enabled: enabled,
+      strict: strict,
+      failingBlock: failingBlock,
+      issueMatcher: issueMatcher
+    )
+  }
 
-func MyXCTExpectFailure(
-  _ failureReason: String,
-  enabled: Bool = true,
-  strict: Bool = true,
-  issueMatcher: ((_XCTIssue) -> Bool)? = nil
-) {
-  XCTExpectFailure(
-    failureReason,
-    enabled: enabled,
-    strict: strict,
-    issueMatcher: issueMatcher
-  )
+  func MyXCTExpectFailure(
+    _ failureReason: String,
+    enabled: Bool = true,
+    strict: Bool = true,
+    issueMatcher: ((_XCTIssue) -> Bool)? = nil
+  ) {
+    XCTExpectFailure(
+      failureReason,
+      enabled: enabled,
+      strict: strict,
+      issueMatcher: issueMatcher
+    )
 }
+#endif
 
 struct Client {
   var p00: () -> Int

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -5,7 +5,7 @@ func MyXCTFail(_ message: String) {
   XCTFail(message)
 }
 
-#if canImport(ObjectiveC)
+#if DEBUG && canImport(ObjectiveC)
   func MyXCTExpectFailure(
     _ failureReason: String,
     enabled: Bool = true,

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -5,8 +5,34 @@ func MyXCTFail(_ message: String) {
   XCTFail(message)
 }
 
-func MyXCTExpectFailure(strict: Bool, message: String, failingBlock: () -> Void) {
-  XCTExpectFailure(message, strict: strict, failingBlock: failingBlock)
+func MyXCTExpectFailure(
+  _ failureReason: String,
+  enabled: Bool = true,
+  strict: Bool = true,
+  failingBlock: () -> Void,
+  issueMatcher: ((_XCTIssue) -> Bool)? = nil
+) {
+  XCTExpectFailure(
+    failureReason,
+    enabled: enabled,
+    strict: strict,
+    failingBlock: failingBlock,
+    issueMatcher: issueMatcher
+  )
+}
+
+func MyXCTExpectFailure(
+  _ failureReason: String,
+  enabled: Bool = true,
+  strict: Bool = true,
+  issueMatcher: ((_XCTIssue) -> Bool)? = nil
+) {
+  XCTExpectFailure(
+    failureReason,
+    enabled: enabled,
+    strict: strict,
+    issueMatcher: issueMatcher
+  )
 }
 
 struct Client {

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -5,6 +5,10 @@ func MyXCTFail(_ message: String) {
   XCTFail(message)
 }
 
+func MyXCTExpectFailure(strict: Bool, message: String, failingBlock: () -> Void) {
+  XCTExpectFailure(message, strict: strict, failingBlock: failingBlock)
+}
+
 struct Client {
   var p00: () -> Int
   var p01: () throws -> Int

--- a/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
@@ -10,7 +10,7 @@
           Unimplemented: f00 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:66
+              XCTestDynamicOverlayTests/TestHelpers.swift:70
           """
       }
 
@@ -21,7 +21,7 @@
           Unimplemented: f01 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:67
+              XCTestDynamicOverlayTests/TestHelpers.swift:71
 
             Invoked with:
               ""
@@ -35,7 +35,7 @@
           Unimplemented: f02 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:68
+              XCTestDynamicOverlayTests/TestHelpers.swift:72
 
             Invoked with:
               ("", 42)
@@ -49,7 +49,7 @@
           Unimplemented: f03 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:69
+              XCTestDynamicOverlayTests/TestHelpers.swift:73
 
             Invoked with:
               ("", 42, 1.2)
@@ -63,7 +63,7 @@
           Unimplemented: f04 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:70
+              XCTestDynamicOverlayTests/TestHelpers.swift:74
 
             Invoked with:
               ("", 42, 1.2, [1, 2])
@@ -79,7 +79,7 @@
           Unimplemented: f05 …
 
             Defined at:
-              XCTestDynamicOverlayTests/TestHelpers.swift:71
+              XCTestDynamicOverlayTests/TestHelpers.swift:75
 
             Invoked with:
               ("", 42, 1.2, [1, 2], XCTestDynamicOverlayTests.User(id: DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF))

--- a/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
@@ -1,5 +1,4 @@
-// TODO: https://github.com/apple/swift-corelibs-xctest/issues/438
-#if !os(Linux) && !os(Windows)
+#if DEBUG && !os(Linux) && !os(Windows)
   import XCTest
 
   final class UnimplementedTests: XCTestCase {

--- a/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
@@ -1,5 +1,5 @@
 // TODO: https://github.com/apple/swift-corelibs-xctest/issues/438
-#if !os(Linux) && !os(Windows)
+#if DEBUG && !os(Linux) && !os(Windows)
   import XCTest
   import XCTestDynamicOverlay
 

--- a/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
@@ -1,4 +1,3 @@
-// TODO: https://github.com/apple/swift-corelibs-xctest/issues/438
 #if DEBUG && !os(Linux) && !os(Windows)
   import XCTest
   import XCTestDynamicOverlay

--- a/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
@@ -1,28 +1,30 @@
 import XCTest
 
-final class XCTExpectFailureTests: XCTestCase {
-  func testXCTDynamicOverlayWithBlockShouldFail() async throws {
-    MyXCTExpectFailure("This is expected to pass.", strict: false) {
-      XCTAssertEqual(42, 42)
-    }
-
-    MyXCTExpectFailure("This is expected to pass.", strict: true) {
-      XCTAssertEqual(42, 1729)
-    } issueMatcher: {
-      $0.compactDescription == #"XCTAssertEqual failed: ("42") is not equal to ("1729")"#
-    }
-
-    if ProcessInfo.processInfo.environment["TEST_FAILURE"] != nil {
-      MyXCTExpectFailure("This is expected to fail!", strict: true) {
+#if DEBUG && canImport(ObjectiveC)
+  final class XCTExpectFailureTests: XCTestCase {
+    func testXCTDynamicOverlayWithBlockShouldFail() async throws {
+      MyXCTExpectFailure("This is expected to pass.", strict: false) {
         XCTAssertEqual(42, 42)
       }
-    }
-  }
 
-  func testXCTDynamicOverlayShouldFail() async throws {
-    MyXCTExpectFailure("This is expected to pass.", strict: true) {
-      $0.compactDescription == #"XCTAssertEqual failed: ("42") is not equal to ("1729")"#
+      MyXCTExpectFailure("This is expected to pass.", strict: true) {
+        XCTAssertEqual(42, 1729)
+      } issueMatcher: {
+        $0.compactDescription == #"XCTAssertEqual failed: ("42") is not equal to ("1729")"#
+      }
+
+      if ProcessInfo.processInfo.environment["TEST_FAILURE"] != nil {
+        MyXCTExpectFailure("This is expected to fail!", strict: true) {
+          XCTAssertEqual(42, 42)
+        }
+      }
     }
-    XCTAssertEqual(42, 1729)
+
+    func testXCTDynamicOverlayShouldFail() async throws {
+      MyXCTExpectFailure("This is expected to pass.", strict: true) {
+        $0.compactDescription == #"XCTAssertEqual failed: ("42") is not equal to ("1729")"#
+      }
+      XCTAssertEqual(42, 1729)
+    }
   }
-}
+#endif

--- a/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+final class XCTExpectFailureTests: XCTestCase {
+  func testXCTDynamicOverlayShouldFail() async throws {
+    MyXCTExpectFailure(strict: false, message: "This is expected to pass.") {
+      XCTAssertEqual(42, 42)
+    }
+
+    MyXCTExpectFailure(strict: true, message: "This is expected to pass.") {
+      XCTAssertEqual(42, 1729)
+    }
+
+    if ProcessInfo.processInfo.environment["TEST_FAILURE"] != nil {
+      MyXCTExpectFailure(strict: true, message: "This is expected to fail!") {
+        XCTAssertEqual(42, 42)
+      }
+    }
+  }
+}

--- a/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
@@ -1,19 +1,28 @@
 import XCTest
 
 final class XCTExpectFailureTests: XCTestCase {
-  func testXCTDynamicOverlayShouldFail() async throws {
-    MyXCTExpectFailure(strict: false, message: "This is expected to pass.") {
+  func testXCTDynamicOverlayWithBlockShouldFail() async throws {
+    MyXCTExpectFailure("This is expected to pass.", strict: false) {
       XCTAssertEqual(42, 42)
     }
 
-    MyXCTExpectFailure(strict: true, message: "This is expected to pass.") {
+    MyXCTExpectFailure("This is expected to pass.", strict: true) {
       XCTAssertEqual(42, 1729)
+    } issueMatcher: {
+      $0.compactDescription == #"XCTAssertEqual failed: ("42") is not equal to ("1729")"#
     }
 
     if ProcessInfo.processInfo.environment["TEST_FAILURE"] != nil {
-      MyXCTExpectFailure(strict: true, message: "This is expected to fail!") {
+      MyXCTExpectFailure("This is expected to fail!", strict: true) {
         XCTAssertEqual(42, 42)
       }
     }
+  }
+
+  func testXCTDynamicOverlayShouldFail() async throws {
+    MyXCTExpectFailure("This is expected to pass.", strict: true) {
+      $0.compactDescription == #"XCTAssertEqual failed: ("42") is not equal to ("1729")"#
+    }
+    XCTAssertEqual(42, 1729)
   }
 }

--- a/Tests/XCTestDynamicOverlayTests/XCTFailTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTFailTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-final class XCTestDynamicOverlayTests: XCTestCase {
+final class XCTFailTests: XCTestCase {
   func testXCTFailShouldFail() async throws {
     if ProcessInfo.processInfo.environment["TEST_FAILURE"] != nil {
       MyXCTFail("This is expected to fail!")


### PR DESCRIPTION
This PR takes the work @ZevEisenberg started with #59 and attempts to take it to the finish line. The changes I've made:

1. Limited `XCTExpectFailure` to Objective-C platforms (it's still [unavailable](https://github.com/apple/swift-corelibs-xctest/issues/438) elsewhere).
1. Finished implementing the official `XCTExpectFailure` signature, including `enabled`, `issueMatcher` and the continuation's return value.
1. Added the version that does not take a failing block.