### PR TITLE
Fix SwiftWasm Glibc import issue

### DIFF
--- a/Sources/XCTestDynamicOverlay/XCTFail.swift
+++ b/Sources/XCTestDynamicOverlay/XCTFail.swift
@@ -181,7 +181,11 @@ public struct XCTFailContext: Sendable {
       return nil
     }
   #else
-    import Glibc
+    #if os(WASI)
+      import WASI
+    #else
+      import Glibc
+    #endif
 
     private func ResolveXCTFail() -> XCTFailType? {
       var hXCTest = dlopen("libXCTest.so", RTLD_NOW)


### PR DESCRIPTION
SwiftWasm introduced its own WASI module awhile back, so we should import that instead of Glibc to avoid potential issues.