### PR TITLE
Use parameter pack in place of generic arguments with limit of 5

### DIFF
--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -5,10 +5,10 @@
 @available(macOS, deprecated: 9999, renamed: "unimplemented")
 @available(tvOS, deprecated: 9999, renamed: "unimplemented")
 @available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<Result>(
+public func XCTUnimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable () -> Result {
+) -> @Sendable (repeat each A) -> Result {
   unimplemented(description(), placeholder: placeholder())
 }
 
@@ -17,136 +17,11 @@ public func XCTUnimplemented<Result>(
 @available(macOS, deprecated: 9999, renamed: "unimplemented")
 @available(tvOS, deprecated: 9999, renamed: "unimplemented")
 @available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<Result>(
+public func XCTUnimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
   line: UInt = #line
-) -> @Sendable () -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A) -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A) -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B) -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B) -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B, C) -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B, C) -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B, C, D) -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B, C, D, E) -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) -> Result {
+) -> @Sendable (repeat each A) -> Result {
   unimplemented(description(), file: file, line: line)
 }
 
@@ -156,88 +31,13 @@ public func XCTUnimplemented<A, B, C, D, E, Result>(
 @available(macOS, deprecated: 9999, renamed: "unimplemented")
 @available(tvOS, deprecated: 9999, renamed: "unimplemented")
 @available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<Result>(
+public func XCTUnimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable () throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A) throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B) throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C) throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D) throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D, E) throws -> Result {
+) -> @Sendable (repeat each A) throws -> Result {
   unimplemented(description())
 }
 
 // MARK: (Parameters) async -> Result
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable () async -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable () async -> Result {
-  unimplemented(description(), file: file, line: line)
-}
 
 /// Returns a closure that generates a failure when invoked.
 ///
@@ -253,10 +53,10 @@ public func XCTUnimplemented<Result>(
 @available(macOS, deprecated: 9999, renamed: "unimplemented")
 @available(tvOS, deprecated: 9999, renamed: "unimplemented")
 @available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, Result>(
+public func XCTUnimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A) async -> Result {
+) -> @Sendable (repeat each A) async -> Result {
   unimplemented(description(), placeholder: placeholder())
 }
 
@@ -265,125 +65,15 @@ public func XCTUnimplemented<A, Result>(
 @available(macOS, deprecated: 9999, renamed: "unimplemented")
 @available(tvOS, deprecated: 9999, renamed: "unimplemented")
 @available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, Result>(
+public func XCTUnimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
   line: UInt = #line
-) -> @Sendable (A) async -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B) async -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B) async -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B, C) async -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B, C) async -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B, C, D) async -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) async -> Result {
-  unimplemented(description(), file: file, line: line)
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result
-) -> @Sendable (A, B, C, D, E) async -> Result {
-  unimplemented(description(), placeholder: placeholder())
-}
-
-@_disfavoredOverload
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) async -> Result {
+) -> @Sendable (repeat each A) async -> Result {
   unimplemented(description(), file: file, line: line)
 }
 
 // MARK: (Parameters) async throws -> Result
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable () async throws -> Result {
-  unimplemented(description())
-}
 
 /// Returns a closure that generates a failure when invoked.
 ///
@@ -394,49 +84,9 @@ public func XCTUnimplemented<Result>(
 @available(macOS, deprecated: 9999, renamed: "unimplemented")
 @available(tvOS, deprecated: 9999, renamed: "unimplemented")
 @available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, Result>(
+public func XCTUnimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A) async throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B) async throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C) async throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D) async throws -> Result {
-  unimplemented(description())
-}
-
-@available(iOS, deprecated: 9999, renamed: "unimplemented")
-@available(macOS, deprecated: 9999, renamed: "unimplemented")
-@available(tvOS, deprecated: 9999, renamed: "unimplemented")
-@available(watchOS, deprecated: 9999, renamed: "unimplemented")
-public func XCTUnimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (A, B, C, D, E) async throws -> Result {
+) -> @Sendable (repeat each A) async throws -> Result {
   unimplemented(description())
 }
 

--- a/Sources/XCTestDynamicOverlay/Unimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/Unimplemented.swift
@@ -1,34 +1,5 @@
 // MARK: (Parameters) -> Result
 
-public func unimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable () -> Result {
-  return {
-    _fail(description(), nil, fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable () -> Result {
-  return {
-    let description = description()
-    _fail(description, nil, fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
 @_disfavoredOverload
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
@@ -56,143 +27,27 @@ public func unimplemented<Result>(
   }
 }
 
-public func unimplemented<A, Result>(
+public func unimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
   fileID: StaticString = #fileID,
   line: UInt = #line
-) -> @Sendable (A) -> Result {
-  return {
-    _fail(description(), $0, fileID: fileID, line: line)
+) -> @Sendable (repeat each A) -> Result {
+  return { (arg: repeat each A) in
+    _fail(description(), (repeat each arg), fileID: fileID, line: line)
     return placeholder()
   }
 }
 
-public func unimplemented<A, Result>(
+public func unimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
   fileID: StaticString = #fileID,
   line: UInt = #line
-) -> @Sendable (A) -> Result {
-  return {
+) -> @Sendable (repeat each A) -> Result {
+  return { (arg: repeat each A) in
     let description = description()
-    _fail(description, $0, fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B) -> Result {
-  return {
-    _fail(description(), ($0, $1), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B) -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1), fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C) -> Result {
-  return {
-    _fail(description(), ($0, $1, $2), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C) -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2), fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) -> Result {
-  return {
-    _fail(description(), ($0, $1, $2, $3), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3), fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) -> Result {
-  return {
-    _fail(description(), ($0, $1, $2, $3, $4), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3, $4), fileID: fileID, line: line)
+    _fail(description, (repeat (each arg)), fileID: fileID, line: line)
     do {
       return try _generatePlaceholder()
     } catch {
@@ -203,108 +58,19 @@ public func unimplemented<A, B, C, D, E, Result>(
 
 // MARK: (Parameters) throws -> Result
 
-public func unimplemented<Result>(
+public func unimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
   line: UInt = #line
-) -> @Sendable () throws -> Result {
-  return {
+) -> @Sendable (repeat each A) throws -> Result {
+  return { (arg: repeat each A) in
     let description = description()
-    _fail(description, nil, fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A) throws -> Result {
-  return {
-    let description = description()
-    _fail(description, $0, fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B) throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1), fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C) throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2), fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3), fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3, $4), fileID: fileID, line: line)
+    _fail(description, (repeat (each arg)), fileID: fileID, line: line)
     throw UnimplementedFailure(description: description)
   }
 }
 
 // MARK: (Parameters) async -> Result
-
-public func unimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable () async -> Result {
-  return {
-    _fail(description(), nil, fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable () async -> Result {
-  return {
-    let description = description()
-    _fail(description, nil, fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
 
 /// Returns a closure that generates a failure when invoked.
 ///
@@ -315,143 +81,27 @@ public func unimplemented<Result>(
 ///     default value (like `()` for `Void`) cannot be returned, calling the closure will fatal
 ///     error instead.
 /// - Returns: A closure that generates a failure when invoked.
-public func unimplemented<A, Result>(
+public func unimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
   fileID: StaticString = #fileID,
   line: UInt = #line
-) -> @Sendable (A) async -> Result {
-  return {
-    _fail(description(), $0, fileID: fileID, line: line)
+) -> @Sendable (repeat each A) async -> Result {
+  return { (arg: repeat each A) in
+    _fail(description(), (repeat (each arg)), fileID: fileID, line: line)
     return placeholder()
   }
 }
 
-public func unimplemented<A, Result>(
+public func unimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
   fileID: StaticString = #fileID,
   line: UInt = #line
-) -> @Sendable (A) async -> Result {
-  return {
+) -> @Sendable (repeat each A) async -> Result {
+  return { (arg: repeat each A) in
     let description = description()
-    _fail(description, $0, fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B) async -> Result {
-  return {
-    _fail(description(), ($0, $1), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B) async -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1), fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C) async -> Result {
-  return {
-    _fail(description(), ($0, $1, $2), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C) async -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2), fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) async -> Result {
-  return {
-    _fail(description(), ($0, $1, $2, $3), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) async -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3), fileID: fileID, line: line)
-    do {
-      return try _generatePlaceholder()
-    } catch {
-      _unimplementedFatalError(description, file: file, line: line)
-    }
-  }
-}
-
-public func unimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  placeholder: @autoclosure @escaping @Sendable () -> Result,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) async -> Result {
-  return {
-    _fail(description(), ($0, $1, $2, $3, $4), fileID: fileID, line: line)
-    return placeholder()
-  }
-}
-
-public func unimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  file: StaticString = #file,
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) async -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3, $4), fileID: fileID, line: line)
+    _fail(description, (repeat (each arg)), fileID: fileID, line: line)
     do {
       return try _generatePlaceholder()
     } catch {
@@ -462,79 +112,19 @@ public func unimplemented<A, B, C, D, E, Result>(
 
 // MARK: (Parameters) async throws -> Result
 
-public func unimplemented<Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable () async throws -> Result {
-  return {
-    let description = description()
-    _fail(description, nil, fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
 /// Returns a closure that generates a failure when invoked.
 ///
 /// - Parameter description: An optional description of the unimplemented closure, for inclusion in
 ///   test results.
 /// - Returns: A closure that generates a failure and throws an error when invoked.
-public func unimplemented<A, Result>(
+public func unimplemented<each A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
   line: UInt = #line
-) -> @Sendable (A) async throws -> Result {
-  return {
+) -> @Sendable (repeat each A) async throws -> Result {
+  return { (arg: repeat each A) in
     let description = description()
-    _fail(description, $0, fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B) async throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1), fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, C, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C) async throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2), fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, C, D, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D) async throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3), fileID: fileID, line: line)
-    throw UnimplementedFailure(description: description)
-  }
-}
-
-public func unimplemented<A, B, C, D, E, Result>(
-  _ description: @autoclosure @escaping @Sendable () -> String = "",
-  fileID: StaticString = #fileID,
-  line: UInt = #line
-) -> @Sendable (A, B, C, D, E) async throws -> Result {
-  return {
-    let description = description()
-    _fail(description, ($0, $1, $2, $3, $4), fileID: fileID, line: line)
+    _fail(description, (repeat (each arg)), fileID: fileID, line: line)
     throw UnimplementedFailure(description: description)
   }
 }


### PR DESCRIPTION
# Parameter pack implementation

Parameter packs are [implemented in Swift 5.9](https://github.com/apple/swift-evolution/blob/main/proposals/0393-parameter-packs.md).

That means we can reduce code to just one method of one type and remove limit on 5 arguments in generic calls. 

First mention about increasing limit is in PR #65 


## Current state

I removed all unimplemented methods with more than one parameter and with zero parameters, because `(repeat each A)` means it could be 0 values (`Void`) or any other number.

Only test that fails is one that records failure but xctestexpectfailure said it doesn't record failure. That's strange. Attaching a screenshot of the issue.

<details><summary>Only failed test</summary>
<p>

<img width="2174" alt="Screenshot 2024-04-23 at 12 35 45" src="https://github.com/pointfreeco/xctest-dynamic-overlay/assets/4246455/5e3cee59-8ac6-43c3-8a22-dc48aca2250e">


</p>
</details> 

That happens only with simple `() -> Int` closure.

```swift
let f00: () -> Int = unimplemented("f00", placeholder: 42)
```