### PR TITLE
Soft-deprecate `unimplemented`

### DIFF
--- a/Sources/XCTestDynamicOverlay/Unimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/Unimplemented.swift
@@ -1,5 +1,25 @@
 // MARK: (Parameters) -> Result
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -12,6 +32,26 @@ public func unimplemented<Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -29,6 +69,26 @@ public func unimplemented<Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 @_disfavoredOverload
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
@@ -40,6 +100,26 @@ public func unimplemented<Result>(
   return placeholder()
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 @_disfavoredOverload
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
@@ -56,6 +136,26 @@ public func unimplemented<Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -68,6 +168,26 @@ public func unimplemented<A, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -85,6 +205,26 @@ public func unimplemented<A, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -97,6 +237,26 @@ public func unimplemented<A, B, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -114,6 +274,26 @@ public func unimplemented<A, B, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -126,6 +306,26 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -143,6 +343,26 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -155,6 +375,26 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -172,6 +412,26 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -184,6 +444,26 @@ public func unimplemented<A, B, C, D, E, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -203,6 +483,26 @@ public func unimplemented<A, B, C, D, E, Result>(
 
 // MARK: (Parameters) throws -> Result
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -215,6 +515,26 @@ public func unimplemented<Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -227,6 +547,26 @@ public func unimplemented<A, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -239,6 +579,26 @@ public func unimplemented<A, B, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -251,6 +611,26 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -263,6 +643,26 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -277,6 +677,26 @@ public func unimplemented<A, B, C, D, E, Result>(
 
 // MARK: (Parameters) async -> Result
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -289,6 +709,26 @@ public func unimplemented<Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -315,6 +755,26 @@ public func unimplemented<Result>(
 ///     default value (like `()` for `Void`) cannot be returned, calling the closure will fatal
 ///     error instead.
 /// - Returns: A closure that generates a failure when invoked.
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -327,6 +787,26 @@ public func unimplemented<A, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -344,6 +824,26 @@ public func unimplemented<A, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -356,6 +856,26 @@ public func unimplemented<A, B, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -373,6 +893,26 @@ public func unimplemented<A, B, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -385,6 +925,26 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -402,6 +962,26 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -414,6 +994,26 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -431,6 +1031,26 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   placeholder: @autoclosure @escaping @Sendable () -> Result,
@@ -443,6 +1063,26 @@ public func unimplemented<A, B, C, D, E, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file: StaticString = #file,
@@ -462,6 +1102,26 @@ public func unimplemented<A, B, C, D, E, Result>(
 
 // MARK: (Parameters) async throws -> Result
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -479,6 +1139,26 @@ public func unimplemented<Result>(
 /// - Parameter description: An optional description of the unimplemented closure, for inclusion in
 ///   test results.
 /// - Returns: A closure that generates a failure and throws an error when invoked.
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -491,6 +1171,26 @@ public func unimplemented<A, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -503,6 +1203,26 @@ public func unimplemented<A, B, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -515,6 +1235,26 @@ public func unimplemented<A, B, C, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -527,6 +1267,26 @@ public func unimplemented<A, B, C, D, Result>(
   }
 }
 
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public func unimplemented<A, B, C, D, E, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   fileID: StaticString = #fileID,
@@ -540,6 +1300,26 @@ public func unimplemented<A, B, C, D, E, Result>(
 }
 
 /// An error thrown from ``XCTUnimplemented(_:)-3obl5``.
+@available(
+  iOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  macOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  tvOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
+@available(
+  watchOS,
+  deprecated: 9999,
+  message: "'unimplemented' has been deprecated in favor of '@DependencyClient' and '@DependencyEndpoint' from the 'swift-dependencies' package. See https://github.com/pointfreeco/swift-dependencies for more information."
+)
 public struct UnimplementedFailure: Error {
   public let description: String
 }


### PR DESCRIPTION
A couple feature requests and pull requests have come in recently for `unimplemented`. While we consider `@DependencyClient` and `@DependencyEndpoint` to be a replacement for `unimplemented`, we still haven't communicated that in the source, so let's do so here via soft-deprecation.