### PR TITLE
Swift Language Support: Drop <5.9, Add 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: apt-get install -y libcurl4-openssl-dev
+        run: apt-get install -y libcurl4-openssl-dev make
       - name: Run tests
         run: make test
       - name: Build for static-stdlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   build:
     name: MacOS
-    runs-on: macOS-latest
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_15.4.app
     - name: Run tests
       run: make test
 
@@ -37,7 +39,7 @@ jobs:
        - uses: bytecodealliance/actions/wasmtime/setup@v1
        - uses: swiftwasm/setup-swiftwasm@v1
          with:
-           swift-version: "wasm-5.9.2-RELEASE"
+           swift-version: "wasm-5.10-RELEASE"
        - name: Build tests
          run: swift build --triple wasm32-unknown-wasi --build-tests
        - name: Run tests
@@ -54,17 +56,12 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-5.8.1-release
-          tag: 5.8.1-RELEASE
+          branch: swift-5.10-release
+          tag: 5.10-RELEASE
       - uses: actions/checkout@v4
       - name: Build
         run: swift build -c ${{ matrix.config }}
       - name: Run tests (debug only)
-        # There is an issue that exists in the 5.8.1 toolchain
-        # which fails on release configuration testing, but
-        # this issue is fixed 5.9 so we can remove the if once
-        # that is generally available.
-        if: ${{ matrix.config == 'debug' }}
         run: swift test
 
   static-stdlib:
@@ -76,7 +73,7 @@ jobs:
     steps:
       - uses: swift-actions/setup-swift@v1
         with:
-          swift-version: '5.8.0'
+          swift-version: '5.10.0'
       - name: Install dependencies
         run: sudo apt-get install -y libcurl4-openssl-dev
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
        - uses: bytecodealliance/actions/wasmtime/setup@v1
        - uses: swiftwasm/setup-swiftwasm@v1
          with:
-           swift-version: "wasm-5.10-RELEASE"
+           swift-version: "wasm-5.9.2-RELEASE"
        - name: Build tests
          run: swift build --triple wasm32-unknown-wasi --build-tests
        - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,22 @@ jobs:
     - name: Run tests
       run: make test
 
-  ubuntu:
-    name: Ubuntu
+  linux:
+    strategy:
+      matrix:
+        swift:
+          - '5.10'
+    name: Ubuntu (Swift ${{ matrix.swift }})
     runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Run tests
-      run: make test-linux
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get install -y libcurl4-openssl-dev
+      - name: Run tests
+        run: make test
+      - name: Build for static-stdlib
+        run: make build-for-static-stdlib
 
   wasm:
      name: Wasm
@@ -63,19 +72,3 @@ jobs:
         run: swift build -c ${{ matrix.config }}
       - name: Run tests (debug only)
         run: swift test
-
-  static-stdlib:
-    name: Static standard library
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: '5.10.0'
-      - name: Install dependencies
-        run: sudo apt-get install -y libcurl4-openssl-dev
-      - uses: actions/checkout@v4
-      - name: Build for static-stdlib
-        run: make build-for-static-stdlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: apt-get install -y libcurl4-openssl-dev make
+        run: apt-get install -y build-essential libcurl4-openssl-dev
       - name: Run tests
         run: make test
       - name: Build for static-stdlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    name: MacOS
+    name: macOS
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: apt-get install -y libcurl4-openssl-dev
       - name: Run tests
         run: make test
       - name: Build for static-stdlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: apt-get install -y build-essential libcurl4-openssl-dev
+        run: apt-get update && apt-get install -y build-essential libcurl4-openssl-dev
       - name: Run tests
         run: make test
       - name: Build for static-stdlib

--- a/Makefile
+++ b/Makefile
@@ -23,19 +23,19 @@ test-linux-docker:
 		--rm \
 		-v "$(PWD):$(PWD)" \
 		-w "$(PWD)" \
-		swift:5.6.2-focal \
+		swift:5.10-focal \
 		bash -c "apt-get update && apt-get install make && make test"
 
 test-linux-static-stdlib:
 	@docker run \
 		-v "$(PWD):$(PWD)" \
 		-w "$(PWD)" \
-		swift:5.6.2-focal \
+		swift:5.10-focal \
 		bash -c "swift build -c debug -Xswiftc -static-stdlib"
 	@docker run \
 		-v "$(PWD):$(PWD)" \
 		-w "$(PWD)" \
-		swift:5.6.2-focal \
+		swift:5.10-focal \
 		bash -c "swift build -c release -Xswiftc -static-stdlib"
 
 build-for-static-stdlib:

--- a/Makefile
+++ b/Makefile
@@ -14,30 +14,6 @@ test-debug:
 test: test-debug
 	@swift test -c release
 
-test-linux: test-debug
-
-test-linux: test
-
-test-linux-docker:
-	@docker run \
-		--rm \
-		-v "$(PWD):$(PWD)" \
-		-w "$(PWD)" \
-		swift:5.10-focal \
-		bash -c "apt-get update && apt-get install make && make test"
-
-test-linux-static-stdlib:
-	@docker run \
-		-v "$(PWD):$(PWD)" \
-		-w "$(PWD)" \
-		swift:5.10-focal \
-		bash -c "swift build -c debug -Xswiftc -static-stdlib"
-	@docker run \
-		-v "$(PWD):$(PWD)" \
-		-w "$(PWD)" \
-		swift:5.10-focal \
-		bash -c "swift build -c release -Xswiftc -static-stdlib"
-
 build-for-static-stdlib:
 	@swift build -c debug --static-swift-stdlib
 	@swift build -c release --static-swift-stdlib

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -19,7 +19,8 @@ let package = Package(
       name: "XCTestDynamicOverlayTests",
       dependencies: ["XCTestDynamicOverlay"]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v6]
 )
 
 #if !os(Windows)

--- a/Sources/XCTestDynamicOverlay/Unimplemented.swift
+++ b/Sources/XCTestDynamicOverlay/Unimplemented.swift
@@ -1487,7 +1487,7 @@ func _fail(_ description: String, _ parameters: Any?, fileID: StaticString, line
       Defined at:
         \(fileID):\(line)
     """
-  if let parameters = parameters {
+  if let parameters {
     var parametersDescription = ""
     debugPrint(parameters, terminator: "", to: &parametersDescription)
     debugDescription.append(

--- a/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
+++ b/Sources/XCTestDynamicOverlay/XCTExpectFailure.swift
@@ -40,7 +40,7 @@ import Foundation
       return try failingBlock()
     }
 
-    if let issueMatcher = issueMatcher {
+    if let issueMatcher {
       let issueMatcher: @convention(block) (AnyObject) -> Bool = { issue in
         issueMatcher(_XCTIssue(issue))
       }
@@ -96,7 +96,7 @@ import Foundation
       return
     }
 
-    if let issueMatcher = issueMatcher {
+    if let issueMatcher {
       let issueMatcher: @convention(block) (AnyObject) -> Bool = { issue in
         issueMatcher(_XCTIssue(issue))
       }

--- a/Tests/XCTestDynamicOverlayTests/CurrentTestCaseTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/CurrentTestCaseTests.swift
@@ -1,4 +1,4 @@
 @_spi(CurrentTestCase) import XCTestDynamicOverlay
 
 // Make sure XCTCurrentTestCase is visible to SPI.
-private let currentTestCase = XCTCurrentTestCase
+@MainActor private let currentTestCase = XCTCurrentTestCase

--- a/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/GeneratePlaceholderTests.swift
@@ -33,9 +33,11 @@
         XCTFail("Stream should be finished")
       }
 
-      let throwingStream: () -> AsyncThrowingStream<Int, Error> = unimplemented("throwingStream")
+      let throwingStream: @Sendable () -> AsyncThrowingStream<Int, Error> = unimplemented(
+        "throwingStream"
+      )
       let result = await Task {
-        try await XCTExpectFailure(failingBlock: throwingStream).first(where: { _ in true })
+        try await XCTExpectFailure { throwingStream() }.first(where: { _ in true })
       }.result
       XCTAssertThrowsError(try result.get()) { XCTAssertTrue($0 is CancellationError) }
 

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -95,12 +95,12 @@ struct Client {
 
 struct User { let id: UUID }
 
-let f00: () -> Int = unimplemented("f00", placeholder: 42)
-let f01: (String) -> Int = unimplemented("f01", placeholder: 42)
-let f02: (String, Int) -> Int = unimplemented("f02", placeholder: 42)
-let f03: (String, Int, Double) -> Int = unimplemented("f03", placeholder: 42)
-let f04: (String, Int, Double, [Int]) -> Int = unimplemented("f04", placeholder: 42)
-let f05: (String, Int, Double, [Int], User) -> Int = unimplemented("f05", placeholder: 42)
+@MainActor let f00: () -> Int = unimplemented("f00", placeholder: 42)
+@MainActor let f01: (String) -> Int = unimplemented("f01", placeholder: 42)
+@MainActor let f02: (String, Int) -> Int = unimplemented("f02", placeholder: 42)
+@MainActor let f03: (String, Int, Double) -> Int = unimplemented("f03", placeholder: 42)
+@MainActor let f04: (String, Int, Double, [Int]) -> Int = unimplemented("f04", placeholder: 42)
+@MainActor let f05: (String, Int, Double, [Int], User) -> Int = unimplemented("f05", placeholder: 42)
 
 private struct Autoclosing {
   init(


### PR DESCRIPTION
We can drop Swift <5.9 now that the App Store requires Xcode 15 for submissions, and we can add 6.0 language mode to keep our concurrency story in check.